### PR TITLE
Remove project delete instruction

### DIFF
--- a/notebooks/gretel-trainer-conditioning.ipynb
+++ b/notebooks/gretel-trainer-conditioning.ipynb
@@ -289,8 +289,7 @@
       "source": [
         "#Uncomment and run these lines to terminate models training in the cloud\n",
         "\n",
-        "#run.cancel_all()\n",
-        "#PROJECT.delete()"
+        "#run.cancel_all()"
       ]
     },
     {

--- a/notebooks/gretel-trainer.ipynb
+++ b/notebooks/gretel-trainer.ipynb
@@ -248,8 +248,7 @@
       "source": [
         "#Uncomment and run these lines to terminate models training in the cloud\n",
         "\n",
-        "#run.cancel_all()\n",
-        "#PROJECT.delete()"
+        "#run.cancel_all()"
       ]
     },
     {


### PR DESCRIPTION
This removes the `PROJECT.delete()` instruction from our notebooks. `run.cancel_all()` isn't blocking, so what will happen is: the models will get cancelled, the project deleted, and then models will error as they go into a cancelled state because the models or project no longer exist.

An alternative approach is to make `Job.cancel()` block from `gretel-client`, but this might be a larger task we want to plan out.