### PR TITLE
Get average sqs score from across partitions

### DIFF
--- a/src/gretel_trainer/runner.py
+++ b/src/gretel_trainer/runner.py
@@ -735,6 +735,12 @@ class StrategyRunner:
         df = self._get_synthetic_data("run", "data")
         return self._maybe_restore_df_headers(df)
 
+    def get_sqs_information(self) -> List[dict]:
+        return [
+            partition.ctx[SQS]
+            for partition in self._strategy.partitions
+        ]
+
     @_needs_load
     def generate_data(
         self,

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -112,7 +112,7 @@ class Trainer:
         )
         return self.run.get_synthetic_data()
 
-    def get_sqs_score(self) -> float:
+    def get_sqs_score(self) -> int:
         """Return the average SQS synthetic data quality score.
 
         Requires the model has been trained.
@@ -121,7 +121,7 @@ class Trainer:
             sqs["synthetic_data_quality_score"]["score"]
             for sqs in self.run.get_sqs_information
         ]
-        return sum(scores) / len(scores)
+        return int(sum(scores) / len(scores))
 
     def _preprocess_data(
         self, dataset_path: str, round_decimals: int = 4

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -112,6 +112,17 @@ class Trainer:
         )
         return self.run.get_synthetic_data()
 
+    def get_sqs_score(self) -> float:
+        """Return the average SQS synthetic data quality score.
+
+        Requires the model has been trained.
+        """
+        scores = [
+            sqs["synthetic_data_quality_score"]["score"]
+            for sqs in self.run.get_sqs_information
+        ]
+        return sum(scores) / len(scores)
+
     def _preprocess_data(
         self, dataset_path: str, round_decimals: int = 4
     ) -> pd.DataFrame:


### PR DESCRIPTION
A few ways we could slice and dice this; I figure there may be additional SQS info we want from the run in the future so I decided to expose the entire `List[dict]` from the runner, and let the trainer pluck out and calculate the first such aggregate, user-friendly data. I'm open to pushing more of this down to the runner and/or transforming the SQS dictionaries into first-class types (likely dataclasses) if anyone has a strong opinion or thinks it'd be useful.