### PR TITLE
Auto-determine best model from training data

### DIFF
--- a/src/gretel_trainer/models.py
+++ b/src/gretel_trainer/models.py
@@ -1,7 +1,26 @@
 import logging
 from typing import Union
 
+import pandas as pd
+
 from gretel_client.projects.models import read_model_config
+
+
+HIGH_COLUMN_THRESHOLD = 20
+HIGH_RECORD_THRESHOLD = 50000
+LOW_COLUMN_THRESHOLD = 4
+LOW_RECORD_THRESHOLD = 1000
+
+
+def determine_best_model(df: pd.DataFrame):
+    row_count, column_count = df.shape
+
+    if row_count > HIGH_RECORD_THRESHOLD or column_count > HIGH_COLUMN_THRESHOLD:
+        return GretelCTGAN(config="synthetics/high-dimensionality")
+    elif row_count < LOW_RECORD_THRESHOLD or column_count < LOW_COLUMN_THRESHOLD:
+        return GretelCTGAN(config="synthetics/low-record-count")
+    else:
+        return GretelLSTM()
 
 
 class _BaseConfig:

--- a/src/gretel_trainer/models.py
+++ b/src/gretel_trainer/models.py
@@ -23,7 +23,7 @@ def determine_best_model(df: pd.DataFrame):
     elif row_count < LOW_RECORD_THRESHOLD or column_count < LOW_COLUMN_THRESHOLD:
         return GretelCTGAN(config="synthetics/low-record-count")
     else:
-        return GretelLSTM()
+        return GretelLSTM(config="synthetics/default")
 
 
 class _BaseConfig:

--- a/src/gretel_trainer/models.py
+++ b/src/gretel_trainer/models.py
@@ -1,7 +1,10 @@
-import logging
-from typing import Union
+from __future__ import annotations
 
-import pandas as pd
+import logging
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from gretel_client.projects.models import read_model_config
 

--- a/src/gretel_trainer/runner.py
+++ b/src/gretel_trainer/runner.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import tempfile
 import time
 from collections import Counter
@@ -789,8 +790,9 @@ class StrategyRunner:
         # NOTE: This payload will be used to create a new payload object per
         # partition, so this will get passed in more as a template to the next
         # routine
+        partition_num_records = math.ceil(num_records / self._strategy.row_partition_count)
         gen_payload = GenPayload(
-            seed_df=seed_df, num_records=num_records, max_invalid=max_invalid
+            seed_df=seed_df, num_records=partition_num_records, max_invalid=max_invalid
         )
 
         logger.info(

--- a/src/gretel_trainer/runner.py
+++ b/src/gretel_trainer/runner.py
@@ -413,11 +413,6 @@ class StrategyRunner:
 
         if "synthetics" in model_config["models"][0].keys():
 
-            model_config["models"][0]["synthetics"]["generate"] = {
-                "num_records": artifact.record_count,
-                "max_invalid": None,
-            }
-
             # If we're trying this model for a second+ time, we reduce the vocab size to
             # utilize the char encoder in order to give a better chance and success
             if attempt > 1:

--- a/src/gretel_trainer/strategy.py
+++ b/src/gretel_trainer/strategy.py
@@ -164,6 +164,10 @@ class PartitionStrategy(BaseModel):
     def partition_count(self) -> int:
         return len(self.partitions)
 
+    @property
+    def row_partition_count(self) -> int:
+        return len(self.partitions) / self.header_cluster_count
+
     def save_to(self, dest: Union[Path, str], overwrite: bool = False):
         location = Path(dest)
         if location.suffix != ".json":

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -74,18 +74,19 @@ class Trainer:
         return model
 
     def train(
-        self, dataset_path: str, round_decimals: int = 4, seed_fields: list = None
+        self, dataset_path: str, delimiter: str = ",", round_decimals: int = 4, seed_fields: list = None,
     ):
         """Train a model on the dataset
 
         Args:
             dataset_path (str): Path or URL to CSV
+            delimiter (str, optional): Delimiter to use when reading the dataset. Defaults to comma (",").
             round_decimals (int, optional): Round decimals in CSV as preprocessing step. Defaults to `4`.
             seed_fields (list, optional): List fields that can be used for conditional generation.
         """
         self.dataset_path = dataset_path
         self.df = self._preprocess_data(
-            dataset_path=dataset_path, round_decimals=round_decimals
+            dataset_path=dataset_path, delimiter=delimiter, round_decimals=round_decimals
         )
         self.run = self._initialize_run(
             df=self.df, overwrite=self.overwrite, seed_fields=seed_fields
@@ -124,10 +125,10 @@ class Trainer:
         return int(sum(scores) / len(scores))
 
     def _preprocess_data(
-        self, dataset_path: str, round_decimals: int = 4
+        self, dataset_path: str, delimiter: str, round_decimals: int = 4
     ) -> pd.DataFrame:
         """Preprocess input data"""
-        tmp = pd.read_csv(dataset_path, low_memory=False)
+        tmp = pd.read_csv(dataset_path, sep=delimiter, low_memory=False)
         tmp = tmp.round(round_decimals)
         return tmp
 

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -157,7 +157,9 @@ class Trainer:
             df = pd.DataFrame()
 
         if not df.empty:
-            self.model_type = determine_best_model(df)
+            if self.model_type is None:
+                self.model_type = determine_best_model(df)
+
             model_config = self.model_type.config
 
             header_clusters = cluster(

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -120,7 +120,7 @@ class Trainer:
         """
         scores = [
             sqs["synthetic_data_quality_score"]["score"]
-            for sqs in self.run.get_sqs_information
+            for sqs in self.run.get_sqs_information()
         ]
         return int(sum(scores) / len(scores))
 

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -24,7 +24,7 @@ class Trainer:
 
     Args:
         project_name (str, optional): Gretel project name. Defaults to "trainer".
-        model_config (_BaseConfig, optional): Options include GretelLSTM(), GretelCTGAN(). If unspecified, the best option will be chosen at train time based on the training dataset.
+        model_type (_BaseConfig, optional): Options include GretelLSTM(), GretelCTGAN(). If unspecified, the best option will be chosen at train time based on the training dataset.
         cache_file (str, optional): Select a path to save or load the cache file. Default is `[project_name]-runner.json`.
         overwrite (bool, optional): Overwrite previous progress. Defaults to True.
     """
@@ -57,7 +57,7 @@ class Trainer:
         """Load an existing project from a cache.
 
         Args:
-            cache_file (str, optional): Valid file path to load the cache file from. Defaults to `[project-name]-runner.json` 
+            cache_file (str, optional): Valid file path to load the cache file from. Defaults to `[project-name]-runner.json`
 
         Returns:
             Trainer: returns an initialized StrategyRunner class.

--- a/src/gretel_trainer/trainer.py
+++ b/src/gretel_trainer/trainer.py
@@ -47,8 +47,11 @@ class Trainer:
         self.cache_file = self._get_cache_file(cache_file)
         self.model_type = model_type
 
-        if self.overwrite and self.model_type is not None:
-            logger.debug(json.dumps(self.model_type.config, indent=2))
+        if self.overwrite:
+            if self.model_type is None:
+                logger.debug("Deferring model configuration to optimize based on training data.")
+            else:
+                logger.debug(json.dumps(self.model_type.config, indent=2))
 
     @classmethod
     def load(
@@ -159,6 +162,7 @@ class Trainer:
         if not df.empty:
             if self.model_type is None:
                 self.model_type = determine_best_model(df)
+                logger.debug(json.dumps(self.model_type.config, indent=2))
 
             model_config = self.model_type.config
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -63,6 +63,10 @@ def test_strategy_all_columns(constraints: PartitionConstraints, test_df):
             <= len(test_df) // constraints.max_row_count + 1
         )
 
+    # partitions are of roughly equal size
+    extracted_df_lengths = [len(partition.extract_df(test_df)) for partition in strategy.partitions]
+    assert max(extracted_df_lengths) - min(extracted_df_lengths) <= 1
+
     # re-assemble all partitions and compare
     compare = pd.DataFrame()
     for idx, partition in enumerate(strategy.partitions):
@@ -101,6 +105,10 @@ def test_strategy_column_batches(
             <= strategy.partition_count / len(header_clusters)
             <= len(test_df) // constraints.max_row_count + 1
         )
+
+    # partitions are of roughly equal size
+    extracted_df_lengths = [len(partition.extract_df(test_df)) for partition in strategy.partitions]
+    assert max(extracted_df_lengths) - min(extracted_df_lengths) <= 1
 
     part1 = pd.DataFrame()
     part2 = pd.DataFrame()


### PR DESCRIPTION
Rather than create a `GretelAuto` model class that would need to override or work around several `_BaseConfig` details (validation, max/limit values, etc.), my goal here is to establish the convention that model type is optional and if you don't specify one when instantiating the Trainer, you're OK with us choosing for you. This is a change from the current behavior (optional but default to LSTM). In this case, we defer setting the trainer instance's `self.model_type` until such time as we can determine the best model to use: namely, at train time when a dataset has been provided.

I'm a little unclear on the `load` (from cache) workflow, which in this branch's implementation would set the StrategyRunner's `model_config` to `None`. I think this is OK because the only methods referencing that value are part of training (`train_all_partitions` => `train_next_partition` => `train_partition`), and that workflow is only kicked off by the Trainer's `train` method, which will load in data and use it to determine and set a concrete model.

I've also added an optional `delimiter` parameter to `train` to help support files with non-comma delimiters.