### PR TITLE
Include dataset name in trainer uploads.

### DIFF
--- a/src/gretel_trainer/runner.py
+++ b/src/gretel_trainer/runner.py
@@ -121,7 +121,9 @@ def _maybe_submit_job(
             logger.warning(
                 "Rate limiting: Max jobs created, skipping new job for now..."
             )
-        return None
+            return None
+        else:
+            raise
 
     return job
 


### PR DESCRIPTION
Add original file name to data sources uploaded as part of trainer projects. This helps disambiguate the data sources from multiple trainer runs where previously they were always named `trainer_0.csv`, `trainer_1.csv`, etc.

Also fixes `StrategyRunner` to not silently swallow all `ApiException`s when submitting a job, so errors not associated with max job limit are still thrown and surfaced to the user.