### PR TITLE
Lift gretel model compatibility to separate module

### DIFF
--- a/src/gretel_trainer/benchmark/gretel/compatibility.py
+++ b/src/gretel_trainer/benchmark/gretel/compatibility.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from gretel_trainer.benchmark.core import DataSource, Datatype
+
+
+def is_runnable(model_key: Optional[str], source: DataSource) -> bool:
+    if model_key is None:
+        return True
+    elif model_key in ("lstm", "synthetics"):
+        return _lstm(source)
+    elif model_key in ("ctgan", "actgan"):
+        return _ctgan(source)
+    elif model_key in ("gpt_x"):
+        return _gptx(source)
+    elif model_key in ("amplify"):
+        return _amplify(source)
+    else:
+        return True
+
+
+def _lstm(source: DataSource) -> bool:
+    return source.column_count <= 150
+
+
+def _ctgan(source: DataSource) -> bool:
+    return True
+
+
+def _gptx(source: DataSource) -> bool:
+    return source.column_count == 1 and source.datatype == Datatype.NATURAL_LANGUAGE
+
+
+def _amplify(source: DataSource) -> bool:
+    return True

--- a/src/gretel_trainer/benchmark/gretel/sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/sdk.py
@@ -8,6 +8,7 @@ from gretel_trainer.benchmark.core import DataSource, Datatype, Evaluator
 from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfig
 
 import gretel_client.helpers
+import gretel_trainer.benchmark.gretel.compatibility as compatibility
 
 from gretel_client.evaluation.quality_report import QualityReport
 from gretel_client.projects.projects import create_or_get_unique_project, search_projects
@@ -92,11 +93,7 @@ class GretelSDKExecutor:
         return self.model.name
 
     def runnable(self, source: DataSource) -> bool:
-        if self.model_key == "gpt_x":
-            if source.column_count > 1 or source.datatype != Datatype.NATURAL_LANGUAGE:
-                return False
-
-        return True
+        return compatibility.is_runnable(self.model_key, source)
 
     def train(self, source: str, **kwargs) -> None:
         project = self.sdk.create_project(self.project_name)

--- a/src/gretel_trainer/benchmark/gretel/trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/trainer.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 from typing_extensions import Protocol
 
 import gretel_trainer
+import gretel_trainer.benchmark.gretel.compatibility as compatibility
 import pandas as pd
 
 from gretel_trainer.benchmark.core import DataSource
@@ -62,11 +63,7 @@ class GretelTrainerExecutor:
         return self.model.name
 
     def runnable(self, source: DataSource) -> bool:
-        if self.model_key is not None and self.model_key in ("lstm", "synthetics"):
-            if source.column_count > 150:
-                return False
-
-        return True
+        return compatibility.is_runnable(self.model_key, source)
 
     def train(self, source: str, **kwargs) -> None:
         Path(self.benchmark_dir).mkdir(exist_ok=True)

--- a/src/gretel_trainer/benchmark/gretel/trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/trainer.py
@@ -27,7 +27,7 @@ def _get_trainer_model_type(
     elif model_name == "ctgan":
         model_class = models.GretelCTGAN
     else:
-        raise Exception(f"Unexpected model name 'f{model_name}' in config")
+        raise Exception(f"Unexpected model name '{model_name}' in config")
 
     return model_class(config=config_dict)
 


### PR DESCRIPTION
### What's here

Make it easier to find the "compatibility rules" for models by lifting the logic to its own module.


#### Why not add this logic to the specific model classes? Wouldn't that be more polymorphic?

The model classes (`GretelLSTM`, `GretelCTGAN`, etc.) are wrappers around _specific configurations_ from the blueprints repo. They do not represent every possible configuration of that model type. If a user wants to run a customized LSTM config, for example, they subclass `GretelModel`, _not_ `GretelLSTM`:
```python
class MyLstm(GretelModel):
    config = "/path/to/my_lstm.yml"
```
Note: they _could_ subclass `GretelLSTM`, but 1) it's easier to tell people to just subclass `GretelModel` regardless of model type, and/because 2) this ultimately treats the model configuration as the source of truth.

If someone mistakenly created a custom Gretel model like this...
```python
class MyGptX(GretelGPTX):
    config = "/path/to/my_amplify.yml"
```
...Benchmark will treat this as an Amplify model, because basically all it does with the class instance is grab the config attribute (and the name—the results output will show the name as `MyGptX`.)