### PR TITLE
Configure session before starting Benchmark comparison

### DIFF
--- a/src/gretel_trainer/benchmark/compare.py
+++ b/src/gretel_trainer/benchmark/compare.py
@@ -157,6 +157,8 @@ def compare(
     gretel_sdk: GretelSDK,
     gretel_trainer_factory: Callable[..., Trainer],
 ) -> Comparison:
+    gretel_sdk.configure_session()
+
     gretel_model_runs: List[Run[GretelExecutor]] = []
     custom_model_runs: List[Run[CustomExecutor]] = []
 

--- a/src/gretel_trainer/benchmark/gretel/sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/sdk.py
@@ -9,6 +9,7 @@ from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfi
 
 import gretel_client.helpers
 
+from gretel_client import configure_session
 from gretel_client.evaluation.quality_report import QualityReport
 from gretel_client.projects.projects import create_or_get_unique_project, search_projects
 
@@ -46,10 +47,15 @@ Poll = Callable[[GretelSDKJob], None]
 
 @dataclass
 class GretelSDK:
-    create_project: Callable[..., GretelSDKProject]
-    search_projects: Callable[..., List[GretelSDKProject]]
+    configure_session: Callable[[], None]
+    create_project: Callable[[str], GretelSDKProject]
+    search_projects: Callable[[str], List[GretelSDKProject]]
     evaluate: Evaluator
     poll: Poll
+
+
+def _configure_session() -> None:
+    return configure_session(api_key="prompt", cache="yes", validate=True)
 
 
 def _create_project(name: str) -> GretelSDKProject:
@@ -67,6 +73,7 @@ def _evaluate(synthetic: pd.DataFrame, reference: str) -> int:
 
 
 ActualGretelSDK = GretelSDK(
+    configure_session=_configure_session,
     create_project=_create_project,
     search_projects=_search_projects,
     evaluate=_evaluate,


### PR DESCRIPTION
### Current behavior

When running in an environment where no Gretel credentials can be found (e.g. Colab), when Benchmark kicks off a comparison the background threads instantiating Trainer instances will prompt for an API key. This is problematic for multiple reasons, all (I believe) due to it running in multiple background threads: it prompts multiple times, doesn't accept input and/or cache properly, and ultimately crashes.

### This fix

Benchmark itself now checks for a configured session before kicking off any real work. It prompts (`api_key="prompt"`) if no credentials are found, validates (`validate=True`) the supplied API key, and caches (`cache="yes"`) it for all the runs it manages. The `configure_session` calls that happen when instantiating Trainer effectively "pass through." I've tested this by installing trainer from this branch in Colab and it is now working as expected.