### PR TITLE
Fix off-by-one difference between project name and run ID

### DIFF
--- a/src/gretel_trainer/benchmark/compare.py
+++ b/src/gretel_trainer/benchmark/compare.py
@@ -170,6 +170,7 @@ def compare(
                 model = model_factory()
                 if isinstance(model, GretelModel):
                     project_name = f"{runtime_config.project_prefix}-{gretel_run_id}"
+                    run_identifier = f"gretel-{gretel_run_id}"
                     gretel_run_id = gretel_run_id + 1
                     executor = _create_gretel_executor(
                         model=model,
@@ -180,7 +181,7 @@ def compare(
                     )
                     gretel_model_runs.append(
                         Run(
-                            identifier=f"gretel-{gretel_run_id}",
+                            identifier=run_identifier,
                             source=source,
                             executor=executor,
                         )


### PR DESCRIPTION
Quick fix so that benchmark's internal run identifier lines up with the project name in Gretel Cloud. We'll eventually have a more user-friendly and stable interface to access detailed run information, but until we figure out how exactly we want that to look and do it, this should make things a little more friendly for those willing to dive into the internals: the models from project `benchmark-{timestamp}-3` will correspond to `comparison.results_dict["gretel-3"]` (instead of `"gretel-4"`)

Note: I considered just using the full project name as the identifier instead of `gretel-{index}`, but we don't have an equivalent to project names for user custom model runs, so I figure the current `[gretel|custom]-{index}` approach is still best for now.