### PR TITLE
Benchmark route Amplify models through Trainer

### DIFF
--- a/src/gretel_trainer/benchmark/compare.py
+++ b/src/gretel_trainer/benchmark/compare.py
@@ -187,12 +187,14 @@ def compare(
                         )
                     )
                 else:
+                    run_identifier = f"custom-{custom_run_id}"
                     custom_run_id = custom_run_id + 1
+                    executor = CustomExecutor(model=model, evaluate=gretel_sdk.evaluate)
                     custom_model_runs.append(
                         Run(
-                            identifier=f"custom-{custom_run_id}",
+                            identifier=run_identifier,
                             source=source,
-                            executor=CustomExecutor(model=model, evaluate=gretel_sdk.evaluate),
+                            executor=executor,
                         )
                     )
 

--- a/src/gretel_trainer/benchmark/gretel/executor.py
+++ b/src/gretel_trainer/benchmark/gretel/executor.py
@@ -1,0 +1,56 @@
+from typing import Callable, Union
+
+import pandas as pd
+
+from gretel_trainer.benchmark.core import DataSource
+from gretel_trainer.benchmark.gretel.models import GretelModel
+from gretel_trainer.benchmark.gretel.sdk import GretelSDK, GretelSDKExecutor
+from gretel_trainer.benchmark.gretel.trainer import GretelTrainerExecutor, Trainer
+
+
+class GretelExecutor:
+    def __init__(
+        self,
+        project_name: str,
+        model: GretelModel,
+        sdk: GretelSDK,
+        trainer_factory: Callable[..., Trainer],
+        benchmark_dir: str,
+    ):
+        self._project_name = project_name
+        self._model = model
+        self._internal_executor = _choose_executor(project_name, model, sdk, trainer_factory, benchmark_dir)
+
+    @property
+    def model_name(self) -> str:
+        return self._model.name
+
+    def runnable(self, source: DataSource) -> bool:
+        return self._model.runnable(source)
+
+    def train(self, source: str, **kwargs) -> None:
+        self._internal_executor.train(source, **kwargs)
+
+    def generate(self, **kwargs) -> pd.DataFrame:
+        return self._internal_executor.generate(**kwargs)
+
+    def get_sqs_score(self, synthetic: pd.DataFrame, reference: str) -> int:
+        return self._internal_executor.get_sqs_score(synthetic, reference)
+
+
+def _choose_executor(
+    project_name: str,
+    model: GretelModel,
+    sdk: GretelSDK,
+    trainer_factory: Callable[..., Trainer],
+    benchmark_dir: str,
+) -> Union[GretelTrainerExecutor, GretelSDKExecutor]:
+    if model.use_trainer:
+        return GretelTrainerExecutor(
+            project_name,
+            model.trainer_model_type,
+            trainer_factory,
+            benchmark_dir
+        )
+    else:
+        return GretelSDKExecutor(project_name, model, sdk)

--- a/src/gretel_trainer/benchmark/gretel/models.py
+++ b/src/gretel_trainer/benchmark/gretel/models.py
@@ -1,15 +1,34 @@
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Optional, Tuple, Union
 
+import gretel_trainer
+
+from gretel_client.projects.exceptions import ModelConfigError
 from gretel_client.projects.models import read_model_config
+from gretel_trainer import models
+from gretel_trainer.benchmark.core import BenchmarkException, DataSource, Datatype
 
 GretelModelConfig = Union[str, Path, Dict]
 
 
-def _config(blueprint: str, class_name: str) -> Dict:
-    config = read_model_config(blueprint)
-    config["name"] = f"benchmark-{class_name}"
-    return config
+TRAINER_MODEL_TYPE_CONSTRUCTORS = {
+    "actgan": models.GretelACTGAN,
+    "amplify": models.GretelAmplify,
+    "ctgan": models.GretelACTGAN,
+    "synthetics": models.GretelLSTM,
+
+    # Benchmark GretelAuto sends None model_type to Trainer to trigger dynamic model selection
+    "AUTO": lambda _: None,
+}
+
+
+def _is_compatible(model_key: Optional[str], source: DataSource) -> bool:
+    if model_key == "synthetics":
+        return source.column_count <= 150
+    elif model_key == "gpt_x":
+        return source.column_count == 1 and source.datatype == Datatype.NATURAL_LANGUAGE
+    else:
+        return True
 
 
 class GretelModel:
@@ -19,14 +38,40 @@ class GretelModel:
     def name(self) -> str:
         return type(self).__name__
 
+    @property
+    def model_key(self) -> str:
+        if self.config == "AUTO":
+            return "AUTO"
+
+        try:
+            config_dict = read_model_config(self.config)
+            return list(config_dict["models"][0])[0]
+        except (ModelConfigError, KeyError):
+            raise BenchmarkException(f"Invalid Gretel model config")
+
+    @property
+    def use_trainer(self) -> bool:
+        return self.model_key in TRAINER_MODEL_TYPE_CONSTRUCTORS.keys()
+
+    @property
+    def trainer_model_type(self) -> Optional[gretel_trainer.models._BaseConfig]:
+        return TRAINER_MODEL_TYPE_CONSTRUCTORS[self.model_key](self.config)
+
+    def runnable(self, source: DataSource) -> bool:
+        return _is_compatible(self.model_key, source)
+
 
 class GretelLSTM(GretelModel):
-    config = _config("synthetics/default", "GretelLSTM")
+    config = "synthetics/default"
 
+class GretelAmplify(GretelModel):
+    config = "synthetics/amplify"
+
+class GretelAuto(GretelModel):
+    config = "AUTO"
 
 class GretelACTGAN(GretelModel):
-    config = _config("synthetics/high-dimensionality", "GretelACTGAN")
-
+    config = "synthetics/high-dimensionality"
 
 class GretelCTGAN(GretelACTGAN):
     """
@@ -34,14 +79,5 @@ class GretelCTGAN(GretelACTGAN):
     """
     ...
 
-
-class GretelAuto(GretelModel):
-    config = "AUTO"
-
-
 class GretelGPTX(GretelModel):
-    config = _config("synthetics/natural-language", "GretelGPTX")
-
-
-class GretelAmplify(GretelModel):
-    config = _config("synthetics/amplify", "GretelAmplify")
+    config = "synthetics/natural-language"

--- a/src/gretel_trainer/benchmark/gretel/sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/sdk.py
@@ -4,7 +4,7 @@ from typing_extensions import Protocol
 
 import pandas as pd
 
-from gretel_trainer.benchmark.core import DataSource, Datatype, Evaluator
+from gretel_trainer.benchmark.core import Evaluator
 from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfig
 
 import gretel_client.helpers
@@ -86,24 +86,11 @@ class GretelSDKExecutor:
         self,
         project_name: str,
         model: GretelModel,
-        model_key: str,
         sdk: GretelSDK,
     ):
         self.project_name = project_name
         self.model = model
-        self.model_key = model_key
         self.sdk = sdk
-
-    @property
-    def model_name(self) -> str:
-        return self.model.name
-
-    def runnable(self, source: DataSource) -> bool:
-        if self.model_key == "gpt_x":
-            if source.column_count > 1 or source.datatype != Datatype.NATURAL_LANGUAGE:
-                return False
-
-        return True
 
     def train(self, source: str, **kwargs) -> None:
         project = self.sdk.create_project(self.project_name)

--- a/src/gretel_trainer/benchmark/gretel/trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/trainer.py
@@ -5,32 +5,6 @@ from typing_extensions import Protocol
 import gretel_trainer
 import pandas as pd
 
-from gretel_trainer.benchmark.core import DataSource
-from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfig
-from gretel_trainer import models
-
-from gretel_client.projects.models import read_model_config
-
-
-def _get_trainer_model_type(
-    config: GretelModelConfig,
-) -> Optional[gretel_trainer.models._BaseConfig]:
-    if config == "AUTO":
-        return None
-
-    config_dict = read_model_config(config)
-    model_name = list(config_dict["models"][0])[0]
-
-    if model_name == "synthetics":
-        model_class = models.GretelLSTM
-    elif model_name == "ctgan" or model_name == "actgan":
-        # ctgan is now replaced with actgan, leaving "ctgan" condition here for backward compatibility
-        model_class = models.GretelACTGAN
-    else:
-        raise Exception(f"Unexpected model name 'f{model_name}' in config")
-
-    return model_class(config=config_dict)
-
 
 class Trainer(Protocol):
     def train(self, source: str, delimiter: Optional[str]) -> None:
@@ -47,34 +21,21 @@ class GretelTrainerExecutor:
     def __init__(
         self,
         project_name: str,
-        model: GretelModel,
-        model_key: Optional[str],
+        trainer_model_type: Optional[gretel_trainer.models._BaseConfig],
         trainer_factory: Callable[..., Trainer],
         benchmark_dir: str,
     ):
         self.project_name = project_name
-        self.model = model
-        self.model_key = model_key
+        self.trainer_model_type = trainer_model_type
         self.trainer_factory = trainer_factory
         self.benchmark_dir = benchmark_dir
-
-    @property
-    def model_name(self) -> str:
-        return self.model.name
-
-    def runnable(self, source: DataSource) -> bool:
-        if self.model_key is not None and self.model_key in ("lstm", "synthetics"):
-            if source.column_count > 150:
-                return False
-
-        return True
 
     def train(self, source: str, **kwargs) -> None:
         Path(self.benchmark_dir).mkdir(exist_ok=True)
         cache_file = f"{self.benchmark_dir}/{self.project_name}-runner.json"
         self.trainer_model = self.trainer_factory(
             project_name=self.project_name,
-            model_type=_get_trainer_model_type(self.model.config),
+            model_type=self.trainer_model_type,
             cache_file=cache_file,
         )
         self.trainer_model.train(source, delimiter=kwargs["delimiter"])

--- a/src/gretel_trainer/models.py
+++ b/src/gretel_trainer/models.py
@@ -148,7 +148,7 @@ class GretelACTGAN(_BaseConfig):
 
     _max_header_clusters_limit: int = 5_000
     _max_rows_limit: int = 5_000_000
-    _model_slug: str = "ctgan"
+    _model_slug: str = "actgan"
 
     def __init__(
         self,


### PR DESCRIPTION
### Top level change
Now that Trainer has a GretelAmplify model, Benchmark uses Trainer for Amplify runs instead of the SDK.

### Refactor
I refactored Benchmark's Gretel models and executors with the goal of centralizing and thus making it simpler to understand:
- which model types use Trainer (opt-in) vs. use the SDK
- the "compatibility requirements" for different models (currently: LSTM <= 150 columns, GPTX == 1 column)

These had been spread across a few different places (`compare.py` determined Trainer/SDK, `gretel/sdk.py` had GPTX compatibility, `gretel/trainer.py` had LSTM compatibility), but now it can all be found in `gretel/models.py`.

At first glance it would seem compatibility requirements could be defined on specific model subclasses to make things more polymorphic. However, Benchmark's Gretel model classes are really just friendly wrappers around _specific model configurations_ (from the blueprints repo) and do not represent all possible instances of that model type running through Benchmark. Instead, we [instruct users](https://docs.gretel.ai/gretel.ai/evaluation-framework/gretel-benchmark#docs-internal-guid-0541ad86-7fff-c59f-d506-94d5782f482f) subclass the generic `GretelModel` base class when they want to provide their own specific Gretel configuration. There are two reasons for this:
1. It's a simpler instruction (always subclass this one thing)
2. It enables us to include model types that are not yet "first class supported," such as DGAN (which we can't support in the same way we do models like Amplify/LSTM/etc. because DGAN's config includes required fields that are specifically coupled to the data source—there is no "one size fits all" blueprint).


### Small fixes

- fix the `model_slug` value for Trainer's `GretelACTGAN` model 
  - :warning: should this be changed to a list `["actgan", "ctgan"]` for a little while for a smoother transition/deprecation experience??
- zero-index custom model runs' run-identifier to match gretel model runs (which were themselves fixed to match project names [here](https://github.com/gretelai/trainer/pull/32))