### PR TITLE
Remove no-op elif case from runner

### DIFF
--- a/src/gretel_trainer/runner.py
+++ b/src/gretel_trainer/runner.py
@@ -441,9 +441,6 @@ class StrategyRunner:
                     "attrs": {"fields": partition.columns.seed_headers},
                 }
 
-        elif "actgan" in model_config["models"][0].keys():
-            pass
-
         model = self._project.create_model_obj(
             data_source=artifact.id, model_config=model_config,
         )


### PR DESCRIPTION
Particularly given that we now have a third model (Amplify) supported in Trainer, we can remove this no-op `elif` clause so that the runner only has special logic for / awareness of LSTM (expand up in the diff for context).