### PR TITLE
Dupe logs

### DIFF
--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -24,7 +24,8 @@ log_levels = {
 log_format = "%(levelname)s - %(asctime)s - %(message)s"
 time_format = "%Y-%m-%d %H:%M:%S"
 
-# Clear out any existing root handlers (Colab)
+# Clear out any existing root handlers
+# (This prevents duplicate log output in Colab)
 for root_handler in logging.root.handlers:
     logging.root.removeHandler(root_handler)
 

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -24,6 +24,11 @@ log_levels = {
 log_format = "%(levelname)s - %(asctime)s - %(message)s"
 time_format = "%Y-%m-%d %H:%M:%S"
 
+# Clear out any existing root handlers (Colab)
+for root_handler in logging.root.handlers:
+    logging.root.removeHandler(root_handler)
+
+# Configure our loggers
 for name, level in log_levels.items():
     logger = logging.getLogger(name)
 

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -37,16 +37,6 @@ class RelationalData:
 
     def log_test(self) -> None:
         logger.info("This is a test")
-        log_to_debug = logging.getLogger("myapp.ui.edit")
-        while log_to_debug is not None:
-            print("level: %s, name: %s (%x), handlers: %s" % (
-                log_to_debug.level,
-                log_to_debug.name,
-                id(log_to_debug),
-                log_to_debug.handlers))
-
-            log_to_debug = log_to_debug.parent
-        logger.info("We're still testing")
 
     def add_table(
         self, table: str, primary_key: Optional[str], data: pd.DataFrame

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -37,6 +37,16 @@ class RelationalData:
 
     def log_test(self) -> None:
         logger.info("This is a test")
+        log_to_debug = logging.getLogger("myapp.ui.edit")
+        while log_to_debug is not None:
+            print("level: %s, name: %s (%x), handlers: %s" % (
+                log_to_debug.level,
+                log_to_debug.name,
+                id(log_to_debug),
+                log_to_debug.handlers))
+
+            log_to_debug = log_to_debug.parent
+        logger.info("We're still testing")
 
     def add_table(
         self, table: str, primary_key: Optional[str], data: pd.DataFrame

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -35,9 +35,6 @@ class RelationalData:
     def __init__(self):
         self.graph = networkx.DiGraph()
 
-    def log_test(self) -> None:
-        logger.info("This is a test")
-
     def add_table(
         self, table: str, primary_key: Optional[str], data: pd.DataFrame
     ) -> None:

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -35,6 +35,9 @@ class RelationalData:
     def __init__(self):
         self.graph = networkx.DiGraph()
 
+    def log_test(self) -> None:
+        logger.info("This is a test")
+
     def add_table(
         self, table: str, primary_key: Optional[str], data: pd.DataFrame
     ) -> None:


### PR DESCRIPTION
It appears Colab preconfigures a default root handler that, when combined with our customized log setup, leads to duplicate log output. This change ensures any root handlers are cleared out before we set up our custom ones. Appears to be working as expected now, and local behavior appears unchanged.