### PR TITLE
Be more opinionated in connector helper functions

### DIFF
--- a/src/gretel_trainer/relational/connectors.py
+++ b/src/gretel_trainer/relational/connectors.py
@@ -107,60 +107,35 @@ def sqlite_conn(path: str) -> Connector:
 
 
 def postgres_conn(
-    user: str, password: str, host: str, port: int, database: Optional[str] = None
+    *, user: str, password: str, host: str, port: int, database: str
 ) -> Connector:
-    conn_string = f"postgresql://{user}:{password}@{host}:{port}"
-    if database is not None:
-        conn_string = f"{conn_string}/{database}"
-
+    conn_string = f"postgresql://{user}:{password}@{host}:{port}/{database}"
     engine = create_engine(conn_string)
     return Connector(engine)
 
 
-def mysql_conn(
-    user: str, password: str, host: str, port: int, database: Optional[str] = None
-):
-    conn_string = f"mysql://{user}:{password}@{host}:{port}"
-    if database is not None:
-        conn_string = f"{conn_string}/{database}"
-
+def mysql_conn(*, user: str, password: str, host: str, port: int, database: str):
+    conn_string = f"mysql://{user}:{password}@{host}:{port}/{database}"
     engine = create_engine(conn_string)
     return Connector(engine)
 
 
-def mariadb_conn(
-    user: str, password: str, host: str, port: int, database: Optional[str] = None
-):
-    conn_string = f"mariadb://{user}:{password}@{host}:{port}"
-    if database is not None:
-        conn_string = f"{conn_string}/{database}"
-
+def mariadb_conn(*, user: str, password: str, host: str, port: int, database: str):
+    conn_string = f"mariadb://{user}:{password}@{host}:{port}/{database}"
     engine = create_engine(conn_string)
     return Connector(engine)
 
 
 def snowflake_conn(
+    *,
     user: str,
     password: str,
     account_identifier: str,
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
-    warehouse: Optional[str] = None,
-    role: Optional[str] = None,
+    database: str,
+    schema: str,
+    warehouse: str,
+    role: str,
 ) -> Connector:
-    conn_string = f"snowflake://{user}:{password}@{account_identifier}"
-
-    if database is not None:
-        conn_string = f"{conn_string}/{database}"
-        if schema is not None:
-            conn_string = f"{conn_string}/{schema}"
-
-    next_sep = "?"
-    if warehouse is not None:
-        conn_string = f"{conn_string}{next_sep}warehouse={warehouse}"
-        next_sep = "&"
-    if role is not None:
-        conn_string = f"{conn_string}{next_sep}role={role}"
-
+    conn_string = f"snowflake://{user}:{password}@{account_identifier}/{database}/{schema}?warehouse={warehouse}&role={role}"
     engine = create_engine(conn_string)
     return Connector(engine)


### PR DESCRIPTION
Testing with snowflake revealed that, while the previously-optional arguments are optional for creating a SQLAlchemy engine generally, for our particular usage of it in the `Connector#extract` method we really need to provide all those arguments; otherwise, sqlalchemy complains during extraction and you just have to start over making a new connection with more arguments supplied. We can nip that in the bud by requiring them all up front.

I updated the other helpers to require a specific database so that we don't try connecting to some multi-db host and extracting an obscene amount of data.

Finally, for sanity purposes, the functions all require keyword arguments, no positional nonsense.

Since these functions are only helpers for creating SQLAlchemy engines, if any of these opinions are too constricting for users, they can always create a SQLA engine themselves and use it to instantiate a Connector. These just seem like more sensible defaults.