### PR TITLE
Downgrade networkx to continue supporting python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.20.28
 gretel-client
 gretel-synthetics[utils]
 jinja2==3.1.1
-networkx==2.8.8
+networkx==2.6.3
 pandas==1.4.0
 pydantic==1.9.0
 scikit-learn==1.1.1


### PR DESCRIPTION
This is the most recent version that supports python 3.7, which is what Colab runs.