### PR TITLE
Internal 3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: |
           python -m pip install --upgrade pip

--- a/src/gretel_trainer/relational/ancestry.py
+++ b/src/gretel_trainer/relational/ancestry.py
@@ -106,7 +106,8 @@ def drop_ancestral_data(df: pd.DataFrame) -> pd.DataFrame:
         col for col in df.columns if col.startswith(f"{_START_LINEAGE}{_END_LINEAGE}")
     ]
     mapper = {
-        col: col.removeprefix(f"{_START_LINEAGE}{_END_LINEAGE}") for col in root_columns
+        col: _removeprefix(col, f"{_START_LINEAGE}{_END_LINEAGE}")
+        for col in root_columns
     }
     return df[root_columns].rename(columns=mapper)
 
@@ -128,3 +129,10 @@ def prepend_foreign_key_lineage(df: pd.DataFrame, fk_col: str) -> pd.DataFrame:
 
     mapper = {col: _adjust(col) for col in df.columns}
     return df.rename(columns=mapper)
+
+
+def _removeprefix(s: str, prefix: str) -> str:
+    if s.startswith(prefix):
+        return s[len(prefix) :]
+    else:
+        return s

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -276,9 +276,10 @@ def test_updates_cross_table_scores_using_evaluate(source_nba, synthetic_nba):
     )
 
     call_args = get_report.call_args
+    call_args_kwargs = call_args[1]  # call_args.kwargs introduced in 3.8
 
-    pdtest.assert_frame_equal(ancestral_source_data, call_args.kwargs["source_data"])
-    pdtest.assert_frame_equal(ancestral_synth_data, call_args.kwargs["synth_data"])
+    pdtest.assert_frame_equal(ancestral_source_data, call_args_kwargs["source_data"])
+    pdtest.assert_frame_equal(ancestral_synth_data, call_args_kwargs["synth_data"])
 
     assert evaluation.cross_table_sqs == 85
     assert evaluation.cross_table_report_json == {"REPORT": "JSON"}


### PR DESCRIPTION
- Two internal code locations where we had been using methods that aren't in 3.7
- Our matrix CI build was running on 3.9 in both builds 🤦 , this has been fixed so we test against both 3.9 and 3.7