### PR TITLE
Upload source on init

### DIFF
--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -135,6 +135,7 @@ class MultiTable:
         self._working_dir = Path(self._project.name)
         os.makedirs(self._working_dir, exist_ok=True)
         self._create_debug_summary()
+        self._upload_sources_to_project(self.relational_data.list_all_tables())
 
     @classmethod
     def restore(cls, backup_file: str) -> MultiTable:
@@ -611,10 +612,6 @@ class MultiTable:
         tables = self.relational_data.list_all_tables()
         self._reset_train_statuses(tables)
 
-        for table in tables:
-            df = self.relational_data.get_table_data(table)
-            self._upload_source_data_to_project(table, df)
-
         training_data = self._prepare_training_data(tables)
         self._train_models(training_data)
 
@@ -626,7 +623,8 @@ class MultiTable:
         """
         for table_name, table_data in tables.items():
             self.relational_data.update_table_data(table_name, table_data)
-            self._upload_source_data_to_project(table_name, table_data)
+
+        self._upload_sources_to_project(list(tables.keys()))
 
         tables_to_retrain = self._strategy.tables_to_retrain(
             list(tables.keys()), self.relational_data
@@ -636,21 +634,14 @@ class MultiTable:
         training_data = self._prepare_training_data(tables_to_retrain)
         self._train_models(training_data)
 
-    def _upload_source_data_to_project(self, table: str, df: pd.DataFrame) -> None:
-        """
-        Uploads source data as a project artifact as `source_{table}.csv`. If an existing
-        artifact exists for the table, removes it so as not to have project artifacts with
-        duplicate names.
-        """
-        existing_source_artifact_id = self._source_artifact_ids.get(table)
-
-        # upload new artifact and track the artifact ID
-        artifact_id = self._upload_df_to_project(df, f"source_{table}")
-        self._source_artifact_ids[table] = artifact_id
-
-        # remove previous artifact if one existed
-        if existing_source_artifact_id is not None:
-            self._project.delete_artifact(existing_source_artifact_id)
+    def _upload_sources_to_project(self, tables: List[str]) -> None:
+        for table in tables:
+            out_path = self._working_dir / f"source_{table}.csv"
+            df = self.relational_data.get_table_data(table)
+            df.to_csv(out_path, index=False)
+            key = upload_gretel_singleton_object(self._project, out_path)
+            self._source_artifact_ids[table] = key
+        self._backup()
 
     def _reset_train_statuses(self, tables: List[str]) -> None:
         for table in tables:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -36,7 +36,7 @@ from gretel_trainer.relational.core import (
 )
 from gretel_trainer.relational.sdk_extras import (
     cautiously_refresh_status,
-    upload_gretel_singleton_object,
+    upload_singleton_project_artifact,
 )
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
@@ -293,7 +293,7 @@ class MultiTable:
         with open(backup_path, "w") as bak:
             json.dump(backup.as_dict, bak)
 
-        upload_gretel_singleton_object(self._project, backup_path)
+        upload_singleton_project_artifact(self._project, backup_path)
         self._latest_backup = backup
 
     def _build_backup(self) -> Backup:
@@ -402,7 +402,7 @@ class MultiTable:
         }
         with open(debug_summary_path, "w") as dbg:
             json.dump(content, dbg)
-        upload_gretel_singleton_object(self._project, debug_summary_path)
+        upload_singleton_project_artifact(self._project, debug_summary_path)
 
     def transform(
         self,
@@ -639,7 +639,7 @@ class MultiTable:
             out_path = self._working_dir / f"source_{table}.csv"
             df = self.relational_data.get_table_data(table)
             df.to_csv(out_path, index=False)
-            key = upload_gretel_singleton_object(self._project, out_path)
+            key = upload_singleton_project_artifact(self._project, out_path)
             self._source_artifact_ids[table] = key
         self._backup()
 

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -5,12 +5,13 @@ from gretel_client.projects import Project
 from gretel_client.projects.jobs import Job, Status
 
 
-def upload_gretel_singleton_object(project: Project, path: Path) -> None:
+def upload_gretel_singleton_object(project: Project, path: Path) -> str:
     latest_key = project.upload_artifact(str(path))
     for artifact in project.artifacts:
         key = artifact["key"]
         if key != latest_key and key.endswith(path.name):
             project.delete_artifact(key)
+    return latest_key
 
 
 def cautiously_refresh_status(

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -5,7 +5,7 @@ from gretel_client.projects import Project
 from gretel_client.projects.jobs import Job, Status
 
 
-def upload_gretel_singleton_object(project: Project, path: Path) -> str:
+def upload_singleton_project_artifact(project: Project, path: Path) -> str:
     latest_key = project.upload_artifact(str(path))
     for artifact in project.artifacts:
         key = artifact["key"]

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -12,11 +12,15 @@ from gretel_trainer.relational.strategies.independent import IndependentStrategy
 def test_model_strategy_combinations(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
+    ), patch(
+        "gretel_trainer.relational.multi_table.create_project"
+    ) as create_project, patch(
+        "gretel_trainer.relational.multi_table.upload_gretel_singleton_object"
+    ) as upload_singleton:
         project = Mock()
         project.name = tmpdir
-        project.artifacts = []
         create_project.return_value = project
+        upload_singleton.return_value = "gretel_abcdefg_source_table.csv"
 
         # Default to Amplify/single-table
         mt = MultiTable(ecom, project_display_name=tmpdir)
@@ -68,11 +72,15 @@ def test_model_strategy_combinations(ecom):
 def test_refresh_interval_config(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
+    ), patch(
+        "gretel_trainer.relational.multi_table.create_project"
+    ) as create_project, patch(
+        "gretel_trainer.relational.multi_table.upload_gretel_singleton_object"
+    ) as upload_singleton:
         project = Mock()
         project.name = tmpdir
-        project.artifacts = []
         create_project.return_value = project
+        upload_singleton.return_value = "gretel_abcdefg_source_table.csv"
 
         # default to 180
         mt = MultiTable(ecom, project_display_name=tmpdir)

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -15,7 +15,7 @@ def test_model_strategy_combinations(ecom):
     ), patch(
         "gretel_trainer.relational.multi_table.create_project"
     ) as create_project, patch(
-        "gretel_trainer.relational.multi_table.upload_gretel_singleton_object"
+        "gretel_trainer.relational.multi_table.upload_singleton_project_artifact"
     ) as upload_singleton:
         project = Mock()
         project.name = tmpdir
@@ -75,7 +75,7 @@ def test_refresh_interval_config(ecom):
     ), patch(
         "gretel_trainer.relational.multi_table.create_project"
     ) as create_project, patch(
-        "gretel_trainer.relational.multi_table.upload_gretel_singleton_object"
+        "gretel_trainer.relational.multi_table.upload_singleton_project_artifact"
     ) as upload_singleton:
         project = Mock()
         project.name = tmpdir


### PR DESCRIPTION
Instead of waiting to upload source CSVs to the project until calling `train`, with this change we will upload them when the MultiTable instance is created. Two reasons for this:
1. Allows restoring from just a created MT instance that hasn't "done" anything yet. Probably not a common use case, but if nothing else it's easier to describe/document the behavior.
2. By uploading the source artifacts right away, we'll be able to (re)use them for transforms.