### PR TITLE
Archives

### DIFF
--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When training is complete, you'll find a number of artifacts in your working directory, including the CSVs on which models were trained (`train_{table}.csv`) and the standard Gretel model artifacts, including HTML and JSON reports and logs (`artifacts_{table}/`).\n",
+    "When training is complete, you'll find a number of artifacts in your working directory, including the CSVs on which models were trained (`synthetics_train_{table}.csv`) and evaluation reports (`synthetics_[type]_evaluation_{table}.[html|json]`).\n",
     "\n",
     "You can also view some evaluation metrics at this point. (We'll expand upon them after generating synthetic data.)"
    ]
@@ -302,7 +302,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have synthetic output data, we can expand the table evaluations to provide another perspective on synthetic data quality."
+    "If we take another look at our evaluations, we'll see additional metrics are available."
    ]
   },
   {
@@ -311,7 +311,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "multitable.expand_evaluations()\n",
     "multitable.evaluations"
    ]
   },
@@ -320,18 +319,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have all the data we need to create a full multitable report that summarizes and explains all this information. After running the cell below you'll find `multitable_report.html` in the working directory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from gretel_trainer.relational import create_report\n",
-    "\n",
-    "create_report(multitable)"
+    "We've also automatically generated a full relational report summarizing and explaining all this information. Look for `relational_report.html` in the working directory."
    ]
   },
   {
@@ -353,7 +341,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The synthetic data is automatically written to the working directory as `synth_{table}.csv`. You can optionally use a `Connector` to write the synthetic data to a database. (If you're writing back to the same database as your source, pass a `prefix: str` argument to the `save` method to avoid overwriting your source tables!)"
+    "The synthetic data is automatically written to the working directory in CSV format as `synth_{table}.csv`. You can optionally use a `Connector` to write the synthetic data to a database. (If you're writing back to the same database as your source, pass a `prefix: str` argument to the `save` method to avoid overwriting your source tables!)"
    ]
   },
   {

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -2,7 +2,9 @@ import logging
 
 # Some of these are imported simply to ensure the logger is instantiated before getting configured below
 import gretel_trainer.relational.sdk_extras
+import gretel_trainer.relational.strategies.ancestral
 import gretel_trainer.relational.strategies.common
+import gretel_trainer.relational.strategies.independent
 from gretel_trainer.relational.connectors import (
     Connector,
     mariadb_conn,
@@ -20,7 +22,9 @@ log_levels = {
     "gretel_trainer.relational.core": "INFO",
     "gretel_trainer.relational.multi_table": "INFO",
     "gretel_trainer.relational.sdk_extras": "INFO",
+    "gretel_trainer.relational.strategies.ancestral": "INFO",
     "gretel_trainer.relational.strategies.common": "INFO",
+    "gretel_trainer.relational.strategies.independent": "INFO",
 }
 
 log_format = "%(levelname)s - %(asctime)s - %(message)s"

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -18,6 +18,7 @@ log_levels = {
     "gretel_trainer.relational.connectors": "INFO",
     "gretel_trainer.relational.core": "INFO",
     "gretel_trainer.relational.multi_table": "INFO",
+    "gretel_trainer.relational.sdk_extras": "INFO",
     "gretel_trainer.relational.strategies.common": "INFO",
 }
 

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+# Some of these are imported simply to ensure the logger is instantiated before getting configured below
+import gretel_trainer.relational.sdk_extras
 import gretel_trainer.relational.strategies.common
 from gretel_trainer.relational.connectors import (
     Connector,
@@ -11,7 +13,6 @@ from gretel_trainer.relational.connectors import (
 )
 from gretel_trainer.relational.core import RelationalData
 from gretel_trainer.relational.multi_table import MultiTable
-from gretel_trainer.relational.report.report import create_report
 
 # Optimize logging for multitable output
 log_levels = {
@@ -41,3 +42,11 @@ for name, level in log_levels.items():
     logger.handlers.clear()
     logger.addHandler(handler)
     logger.setLevel(level)
+
+
+def create_report(multitable: MultiTable) -> None:
+    logger = logging.getLogger("gretel_trainer.relational.multi_table")
+    logger.info(
+        "The `create_report` function is deprecated and will be removed in a future release. Instead call the `MultiTable#create_relational_report` instance method."
+    )
+    multitable.create_relational_report()

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -6,7 +6,6 @@ from gretel_client.projects import Project
 
 @dataclass
 class ArtifactCollection:
-    project: Project
     gretel_backup: Optional[str] = None
     gretel_debug_summary: Optional[str] = None
     transforms_output_archive: Optional[str] = None
@@ -14,32 +13,32 @@ class ArtifactCollection:
     synthetics_output_archive: Optional[str] = None
     synthetics_reports_archive: Optional[str] = None
 
-    def upload_gretel_backup(self, path: str) -> None:
+    def upload_gretel_backup(self, project: Project, path: str) -> None:
         existing = self.gretel_backup
-        self.gretel_backup = self._upload_file(path, existing)
+        self.gretel_backup = self._upload_file(project, path, existing)
 
-    def upload_gretel_debug_summary(self, path: str) -> None:
+    def upload_gretel_debug_summary(self, project: Project, path: str) -> None:
         existing = self.gretel_debug_summary
-        self.gretel_debug_summary = self._upload_file(path, existing)
+        self.gretel_debug_summary = self._upload_file(project, path, existing)
 
-    def upload_transforms_output_archive(self, path: str) -> None:
+    def upload_transforms_output_archive(self, project: Project, path: str) -> None:
         existing = self.transforms_output_archive
-        self.transforms_output_archive = self._upload_file(path, existing)
+        self.transforms_output_archive = self._upload_file(project, path, existing)
 
-    def upload_synthetics_source_archive(self, path: str) -> None:
+    def upload_synthetics_source_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_source_archive
-        self.synthetics_source_archive = self._upload_file(path, existing)
+        self.synthetics_source_archive = self._upload_file(project, path, existing)
 
-    def upload_synthetics_output_archive(self, path: str) -> None:
+    def upload_synthetics_output_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_output_archive
-        self.synthetics_output_archive = self._upload_file(path, existing)
+        self.synthetics_output_archive = self._upload_file(project, path, existing)
 
-    def upload_synthetics_reports_archive(self, path: str) -> None:
+    def upload_synthetics_reports_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_reports_archive
-        self.synthetics_reports_archive = self._upload_file(path, existing)
+        self.synthetics_reports_archive = self._upload_file(project, path, existing)
 
-    def _upload_file(self, path: str, existing: Optional[str]) -> str:
-        latest = self.project.upload_artifact(path)
+    def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> str:
+        latest = project.upload_artifact(path)
         if existing is not None:
-            self.project.delete_artifact(existing)
+            project.delete_artifact(existing)
         return latest

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -11,14 +11,6 @@ class ArtifactCollection:
     synthetics_outputs_archive: Optional[str] = None
     transforms_output_archive: Optional[str] = None
 
-    # Backup behaves differently to avoid constantly busting the cache
-    def upload_gretel_backup(self, project: Project, path: str) -> None:
-        latest = project.upload_artifact(path)
-        for artifact in project.artifacts:
-            key = artifact["key"]
-            if key != latest and key.endswith("__gretel_backup.json"):
-                project.delete_artifact(key)
-
     def upload_gretel_debug_summary(self, project: Project, path: str) -> None:
         existing = self.gretel_debug_summary
         self.gretel_debug_summary = self._upload_file(project, path, existing)

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -23,10 +23,6 @@ class ArtifactCollection:
         existing = self.gretel_debug_summary
         self.gretel_debug_summary = self._upload_file(project, path, existing)
 
-    def upload_transforms_output_archive(self, project: Project, path: str) -> None:
-        existing = self.transforms_output_archive
-        self.transforms_output_archive = self._upload_file(project, path, existing)
-
     def upload_source_archive(self, project: Project, path: str) -> None:
         existing = self.source_archive
         self.source_archive = self._upload_file(project, path, existing)
@@ -34,6 +30,10 @@ class ArtifactCollection:
     def upload_synthetics_outputs_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_outputs_archive
         self.synthetics_outputs_archive = self._upload_file(project, path, existing)
+
+    def upload_transforms_output_archive(self, project: Project, path: str) -> None:
+        existing = self.transforms_output_archive
+        self.transforms_output_archive = self._upload_file(project, path, existing)
 
     def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> str:
         latest = project.upload_artifact(path)

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -8,7 +8,7 @@ from gretel_client.projects import Project
 class ArtifactCollection:
     gretel_debug_summary: Optional[str] = None
     transforms_output_archive: Optional[str] = None
-    synthetics_source_archive: Optional[str] = None
+    source_archive: Optional[str] = None
     synthetics_outputs_archive: Optional[str] = None
 
     # Backup behaves differently to avoid constantly busting the cache
@@ -27,9 +27,9 @@ class ArtifactCollection:
         existing = self.transforms_output_archive
         self.transforms_output_archive = self._upload_file(project, path, existing)
 
-    def upload_synthetics_source_archive(self, project: Project, path: str) -> None:
-        existing = self.synthetics_source_archive
-        self.synthetics_source_archive = self._upload_file(project, path, existing)
+    def upload_source_archive(self, project: Project, path: str) -> None:
+        existing = self.source_archive
+        self.source_archive = self._upload_file(project, path, existing)
 
     def upload_synthetics_outputs_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_outputs_archive

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -6,16 +6,19 @@ from gretel_client.projects import Project
 
 @dataclass
 class ArtifactCollection:
-    gretel_backup: Optional[str] = None
     gretel_debug_summary: Optional[str] = None
     transforms_output_archive: Optional[str] = None
     synthetics_source_archive: Optional[str] = None
     synthetics_output_archive: Optional[str] = None
     synthetics_reports_archive: Optional[str] = None
 
+    # Backup behaves differently to avoid constantly busting the cache
     def upload_gretel_backup(self, project: Project, path: str) -> None:
-        existing = self.gretel_backup
-        self.gretel_backup = self._upload_file(project, path, existing)
+        latest = project.upload_artifact(path)
+        for artifact in project.artifacts:
+            key = artifact["key"]
+            if key != latest and key.endswith("__gretel_backup.json"):
+                project.delete_artifact(key)
 
     def upload_gretel_debug_summary(self, project: Project, path: str) -> None:
         existing = self.gretel_debug_summary

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-from typing import Dict, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from gretel_client.projects import Project
 
@@ -9,11 +9,8 @@ class ArtifactCollection:
     project: Project
     gretel_backup: Optional[str] = None
     gretel_debug_summary: Optional[str] = None
-    transforms_source_tables: Dict[str, str] = field(default_factory=dict)
     transforms_output_archive: Optional[str] = None
     synthetics_source_archive: Optional[str] = None
-    synthetics_train_tables: Dict[str, str] = field(default_factory=dict)
-    synthetics_seeds: Dict[str, str] = field(default_factory=dict)
     synthetics_output_archive: Optional[str] = None
     synthetics_reports_archive: Optional[str] = None
 
@@ -25,10 +22,6 @@ class ArtifactCollection:
         existing = self.gretel_debug_summary
         self.gretel_debug_summary = self._upload_file(path, existing)
 
-    def upload_transforms_source_table(self, path: str, table_name: str) -> None:
-        existing = self.transforms_source_tables.get(table_name)
-        self.transforms_source_tables[table_name] = self._upload_file(path, existing)
-
     def upload_transforms_output_archive(self, path: str) -> None:
         existing = self.transforms_output_archive
         self.transforms_output_archive = self._upload_file(path, existing)
@@ -36,14 +29,6 @@ class ArtifactCollection:
     def upload_synthetics_source_archive(self, path: str) -> None:
         existing = self.synthetics_source_archive
         self.synthetics_source_archive = self._upload_file(path, existing)
-
-    def upload_synthetics_train_table(self, path: str, table_name: str) -> None:
-        existing = self.synthetics_train_tables.get(table_name)
-        self.synthetics_train_tables[table_name] = self._upload_file(path, existing)
-
-    def upload_synthetics_seed(self, path: str, table_name: str) -> None:
-        existing = self.synthetics_seeds.get(table_name)
-        self.synthetics_seeds[table_name] = self._upload_file(path, existing)
 
     def upload_synthetics_output_archive(self, path: str) -> None:
         existing = self.synthetics_output_archive

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -7,9 +7,9 @@ from gretel_client.projects import Project
 @dataclass
 class ArtifactCollection:
     gretel_debug_summary: Optional[str] = None
-    transforms_output_archive: Optional[str] = None
     source_archive: Optional[str] = None
     synthetics_outputs_archive: Optional[str] = None
+    transforms_output_archive: Optional[str] = None
 
     # Backup behaves differently to avoid constantly busting the cache
     def upload_gretel_backup(self, project: Project, path: str) -> None:

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from gretel_client.projects import Project
+
+
+@dataclass
+class ArtifactCollection:
+    project: Project
+    gretel_backup: Optional[str] = None
+    gretel_debug_summary: Optional[str] = None
+    transforms_source_tables: Dict[str, str] = field(default_factory=dict)
+    transforms_output_archive: Optional[str] = None
+    synthetics_source_archive: Optional[str] = None
+    synthetics_train_tables: Dict[str, str] = field(default_factory=dict)
+    synthetics_seeds: Dict[str, str] = field(default_factory=dict)
+    synthetics_output_archive: Optional[str] = None
+    synthetics_reports_archive: Optional[str] = None
+
+    def upload_gretel_backup(self, path: str) -> None:
+        existing = self.gretel_backup
+        self.gretel_backup = self._upload_file(path, existing)
+
+    def upload_gretel_debug_summary(self, path: str) -> None:
+        existing = self.gretel_debug_summary
+        self.gretel_debug_summary = self._upload_file(path, existing)
+
+    def upload_transforms_source_table(self, path: str, table_name: str) -> None:
+        existing = self.transforms_source_tables.get(table_name)
+        self.transforms_source_tables[table_name] = self._upload_file(path, existing)
+
+    def upload_transforms_output_archive(self, path: str) -> None:
+        existing = self.transforms_output_archive
+        self.transforms_output_archive = self._upload_file(path, existing)
+
+    def upload_synthetics_source_archive(self, path: str) -> None:
+        existing = self.synthetics_source_archive
+        self.synthetics_source_archive = self._upload_file(path, existing)
+
+    def upload_synthetics_train_table(self, path: str, table_name: str) -> None:
+        existing = self.synthetics_train_tables.get(table_name)
+        self.synthetics_train_tables[table_name] = self._upload_file(path, existing)
+
+    def upload_synthetics_seed(self, path: str, table_name: str) -> None:
+        existing = self.synthetics_seeds.get(table_name)
+        self.synthetics_seeds[table_name] = self._upload_file(path, existing)
+
+    def upload_synthetics_output_archive(self, path: str) -> None:
+        existing = self.synthetics_output_archive
+        self.synthetics_output_archive = self._upload_file(path, existing)
+
+    def upload_synthetics_reports_archive(self, path: str) -> None:
+        existing = self.synthetics_reports_archive
+        self.synthetics_reports_archive = self._upload_file(path, existing)
+
+    def _upload_file(self, path: str, existing: Optional[str]) -> str:
+        latest = self.project.upload_artifact(path)
+        if existing is not None:
+            self.project.delete_artifact(existing)
+        return latest

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -9,8 +9,7 @@ class ArtifactCollection:
     gretel_debug_summary: Optional[str] = None
     transforms_output_archive: Optional[str] = None
     synthetics_source_archive: Optional[str] = None
-    synthetics_output_archive: Optional[str] = None
-    synthetics_reports_archive: Optional[str] = None
+    synthetics_outputs_archive: Optional[str] = None
 
     # Backup behaves differently to avoid constantly busting the cache
     def upload_gretel_backup(self, project: Project, path: str) -> None:
@@ -32,13 +31,9 @@ class ArtifactCollection:
         existing = self.synthetics_source_archive
         self.synthetics_source_archive = self._upload_file(project, path, existing)
 
-    def upload_synthetics_output_archive(self, project: Project, path: str) -> None:
-        existing = self.synthetics_output_archive
-        self.synthetics_output_archive = self._upload_file(project, path, existing)
-
-    def upload_synthetics_reports_archive(self, project: Project, path: str) -> None:
-        existing = self.synthetics_reports_archive
-        self.synthetics_reports_archive = self._upload_file(project, path, existing)
+    def upload_synthetics_outputs_archive(self, project: Project, path: str) -> None:
+        existing = self.synthetics_outputs_archive
+        self.synthetics_outputs_archive = self._upload_file(project, path, existing)
 
     def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> str:
         latest = project.upload_artifact(path)

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -9,7 +9,6 @@ from gretel_trainer.relational.core import ForeignKey
 
 @dataclass
 class BackupRelationalDataTable:
-    source_artifact_id: str
     primary_key: Optional[str]
 
 

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -45,7 +45,6 @@ class BackupTrain:
 @dataclass
 class BackupGenerateTable:
     record_handler_id: str
-    synthetic_artifact_id: Optional[str] = None
 
 
 @dataclass

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from gretel_trainer.relational.artifacts import ArtifactCollection
 from gretel_trainer.relational.core import ForeignKey
 
 
@@ -61,6 +62,7 @@ class Backup:
     gretel_model: str
     working_dir: str
     refresh_interval: int
+    artifact_collection: ArtifactCollection
     relational_data: BackupRelationalData
     train: Optional[BackupTrain] = None
     generate: Optional[BackupGenerate] = None
@@ -92,6 +94,7 @@ class Backup:
             gretel_model=b["gretel_model"],
             working_dir=b["working_dir"],
             refresh_interval=b["refresh_interval"],
+            artifact_collection=ArtifactCollection(**b["artifact_collection"]),
             relational_data=brd,
         )
 

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -23,6 +23,14 @@ class TableEvaluation:
     individual_report_json: Optional[Dict] = field(default=None, repr=False)
     individual_sqs: Optional[int] = None
 
+    def is_complete(self) -> bool:
+        return (
+            self.cross_table_report_json is not None
+            and self.cross_table_sqs is not None
+            and self.individual_report_json is not None
+            and self.individual_sqs is not None
+        )
+
 
 @dataclass
 class ForeignKey:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -39,7 +39,8 @@ from gretel_trainer.relational.core import (
 )
 from gretel_trainer.relational.sdk_extras import (
     cautiously_refresh_status,
-    download_one_artifact,
+    download_file_artifact,
+    download_tar_artifact,
 )
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
@@ -219,7 +220,7 @@ class MultiTable:
                 "Cannot restore from backup—source table archive is missing."
             )
         source_archive_path = working_dir / "synthetics_source_tables.tar.gz"
-        download_one_artifact(project, source_archive_id, source_archive_path)
+        download_tar_artifact(project, source_archive_id, source_archive_path)
         with tarfile.open(source_archive_path, "r:gz") as tar:
             tar.extractall()
 
@@ -260,7 +261,7 @@ class MultiTable:
                     "Cannot restore while model training is actively in progress."
                 )
             else:
-                download_one_artifact(
+                download_file_artifact(
                     project,
                     model.data_source,
                     working_dir / f"synthetics_train_{table_name}.csv",
@@ -299,7 +300,7 @@ class MultiTable:
             data_source = record_handler.data_source
             if data_source is not None:
                 out_path = working_dir / f"synthetics_seed_{table_name}.csv"
-                download_one_artifact(project, data_source, out_path)
+                download_file_artifact(project, data_source, out_path)
 
         restore_config.record_handlers = record_handlers
 
@@ -310,7 +311,7 @@ class MultiTable:
             synthetics_output_archive_path = (
                 working_dir / "synthetics_output_tables.tar.gz"
             )
-            download_one_artifact(
+            download_tar_artifact(
                 project, synthetics_output_archive_id, synthetics_output_archive_path
             )
             with tarfile.open(synthetics_output_archive_path, "r:gz") as tar:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -481,7 +481,7 @@ class MultiTable:
         )
 
         if in_place:
-            for table_name, transformed_table in output_tables:
+            for table_name, transformed_table in output_tables.items():
                 self.relational_data.update_table_data(table_name, transformed_table)
 
         self.transform_output_tables = output_tables

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -216,6 +216,12 @@ class MultiTable:
         )
 
         artifact_collection = backup.artifact_collection
+
+        debug_summary_id = artifact_collection.gretel_debug_summary
+        if debug_summary_id is not None:
+            debug_summary_path = working_dir / "_gretel_debug_summary.json"
+            download_file_artifact(project, debug_summary_id, debug_summary_path)
+
         source_archive_id = artifact_collection.source_archive
         if source_archive_id is None:
             raise MultiTableException(

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -324,7 +324,7 @@ class MultiTable:
                 synthetic_output_tables[table_name] = pd.read_csv(str(local_synth_path))
             restore_config.synthetic_output_tables = synthetic_output_tables
             # TODO: somewhere around here, restore evaluations
-            restore_config.log_message = "Generation jobs for all tables from previous run finished prior to backup. From here, you can review your synthetic data via `synthetic_output_tables` or call `expand_evaluations` for additional SQS metrics."
+            restore_config.log_message = "Generation jobs for all tables from previous run finished prior to backup. From here, you can access your synthetic data as Pandas DataFrames via `synthetic_output_tables`, or review them in CSV format along with the relational report in the local working directory."
 
         return _create_multitable(rel_data, backup, restore_config)
 
@@ -875,9 +875,6 @@ class MultiTable:
         Adds evaluation metrics for the "opposite" correlation strategy using the Gretel Evaluate API.
         """
         for table_name in output_tables:
-            logger.info(
-                f"Expanding evaluation metrics for `{table_name}` via Gretel Evaluate API."
-            )
             self._strategy.update_evaluation_via_evaluate(
                 evaluation=self.evaluations[table_name],
                 table=table_name,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -856,9 +856,9 @@ class MultiTable:
         }
         self._expand_evaluations(tables_with_incomplete_evaluations)
 
+        logger.info("Creating relational report")
         self.create_relational_report()
 
-        logger.info("Collecting all synthetic outputs")
         archive_path = self._working_dir / "synthetics_outputs.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
             tar.add(self._working_dir / "relational_report.html")

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -258,7 +258,9 @@ class MultiTable:
                 )
             else:
                 _download_artifact(
-                    project, model.data_source, working_dir / f"train_{table_name}.csv"
+                    project,
+                    model.data_source,
+                    working_dir / f"synthetics_train_{table_name}.csv",
                 )
                 logger.info(
                     f"Restored model for `{table_name}` with status {train_status}."
@@ -293,7 +295,7 @@ class MultiTable:
             record_handlers[table_name] = record_handler
             data_source = record_handler.data_source
             if data_source is not None:
-                out_path = working_dir / f"seed_{table_name}.csv"
+                out_path = working_dir / f"synthetics_seed_{table_name}.csv"
                 _download_artifact(project, data_source, out_path)
 
         restore_config.record_handlers = record_handlers
@@ -569,7 +571,7 @@ class MultiTable:
         training_paths = {}
 
         for table_name in tables:
-            training_path = self._working_dir / f"train_{table_name}.csv"
+            training_path = self._working_dir / f"synthetics_train_{table_name}.csv"
             training_data[table_name].to_csv(training_path, index=False)
             training_paths[table_name] = training_path
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -349,7 +349,7 @@ class MultiTable:
         with open(backup_path, "w") as bak:
             json.dump(backup.as_dict, bak)
 
-        self._artifact_collection.upload_gretel_backup(self._project, str(backup_path))
+        _upload_gretel_backup(self._project, str(backup_path))
 
         self._latest_backup = backup
 
@@ -1059,3 +1059,11 @@ def _mkdir(name: str) -> Path:
     d = Path(name)
     os.makedirs(d, exist_ok=True)
     return d
+
+
+def _upload_gretel_backup(project: Project, path: str) -> None:
+    latest = project.upload_artifact(path)
+    for artifact in project.artifacts:
+        key = artifact["key"]
+        if key != latest and key.endswith("__gretel_backup.json"):
+            project.delete_artifact(key)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -120,7 +120,7 @@ class MultiTable:
             )
 
         self.relational_data = relational_data
-        self._artifact_collection = ArtifactCollection(project=self._project)
+        self._artifact_collection = ArtifactCollection()
         self._latest_backup: Optional[Backup] = None
         self._models: Dict[str, Model] = {}
         self._record_handlers: Dict[str, RecordHandler] = {}
@@ -287,7 +287,7 @@ class MultiTable:
         with open(backup_path, "w") as bak:
             json.dump(backup.as_dict, bak)
 
-        self._artifact_collection.upload_gretel_backup(str(backup_path))
+        self._artifact_collection.upload_gretel_backup(self._project, str(backup_path))
 
         self._latest_backup = backup
 
@@ -391,7 +391,9 @@ class MultiTable:
         }
         with open(debug_summary_path, "w") as dbg:
             json.dump(content, dbg)
-        self._artifact_collection.upload_gretel_debug_summary(str(debug_summary_path))
+        self._artifact_collection.upload_gretel_debug_summary(
+            self._project, str(debug_summary_path)
+        )
 
     def transform(
         self,
@@ -630,7 +632,9 @@ class MultiTable:
             for table in self.relational_data.list_all_tables()
         }
         self._archive(source_dataframes, archive_path, "source_")
-        self._artifact_collection.upload_synthetics_source_archive(str(archive_path))
+        self._artifact_collection.upload_synthetics_source_archive(
+            self._project, str(archive_path)
+        )
         self._backup()
 
     def _reset_train_statuses(self, tables: List[str]) -> None:
@@ -785,7 +789,9 @@ class MultiTable:
 
         archive_path = self._working_dir / "synthetics_output_tables.tar.gz"
         self._archive(output_tables, archive_path, "synth_")
-        self._artifact_collection.upload_synthetics_output_archive(str(archive_path))
+        self._artifact_collection.upload_synthetics_output_archive(
+            self._project, str(archive_path)
+        )
         self._backup()
         self.synthetic_output_tables = output_tables
         return self.synthetic_output_tables

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -216,12 +216,12 @@ class MultiTable:
         )
 
         artifact_collection = backup.artifact_collection
-        source_archive_id = artifact_collection.synthetics_source_archive
+        source_archive_id = artifact_collection.source_archive
         if source_archive_id is None:
             raise MultiTableException(
-                "Cannot restore from backup—source table archive is missing."
+                "Cannot restore from backup: source archive is missing."
             )
-        source_archive_path = working_dir / "synthetics_source_tables.tar.gz"
+        source_archive_path = working_dir / "source_tables.tar.gz"
         download_tar_artifact(project, source_archive_id, source_archive_path)
         with tarfile.open(source_archive_path, "r:gz") as tar:
             tar.extractall()
@@ -229,7 +229,7 @@ class MultiTable:
         # Restore RelationalData instance
         rel_data = RelationalData()
         for table_name, table_backup in backup.relational_data.tables.items():
-            local_source_path = working_dir / f"synthetics_source_{table_name}.csv"
+            local_source_path = working_dir / f"source_{table_name}.csv"
             source_data = pd.read_csv(str(local_source_path))
             rel_data.add_table(
                 name=table_name, primary_key=table_backup.primary_key, data=source_data
@@ -677,14 +677,14 @@ class MultiTable:
         self._train_models(training_data)
 
     def _upload_sources_to_project(self) -> None:
-        archive_path = self._working_dir / "synthetics_source_tables.tar.gz"
+        archive_path = self._working_dir / "source_tables.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
             for table in self.relational_data.list_all_tables():
-                out_path = self._working_dir / f"synthetics_source_{table}.csv"
+                out_path = self._working_dir / f"source_{table}.csv"
                 df = self.relational_data.get_table_data(table)
                 df.to_csv(out_path, index=False)
                 tar.add(out_path)
-        self._artifact_collection.upload_synthetics_source_archive(
+        self._artifact_collection.upload_source_archive(
             self._project, str(archive_path)
         )
         self._backup()

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -36,10 +36,7 @@ from gretel_trainer.relational.core import (
     RelationalData,
     TableEvaluation,
 )
-from gretel_trainer.relational.sdk_extras import (
-    cautiously_refresh_status,
-    upload_singleton_project_artifact,
-)
+from gretel_trainer.relational.sdk_extras import cautiously_refresh_status
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -290,7 +290,8 @@ class MultiTable:
         with open(backup_path, "w") as bak:
             json.dump(backup.as_dict, bak)
 
-        upload_singleton_project_artifact(self._project, backup_path)
+        self._artifact_collection.upload_gretel_backup(str(backup_path))
+
         self._latest_backup = backup
 
     def _build_backup(self) -> Backup:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -394,7 +394,7 @@ class MultiTable:
         }
         with open(debug_summary_path, "w") as dbg:
             json.dump(content, dbg)
-        upload_singleton_project_artifact(self._project, debug_summary_path)
+        self._artifact_collection.upload_gretel_debug_summary(str(debug_summary_path))
 
     def transform(
         self,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -8,6 +8,7 @@ import tarfile
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import replace
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -332,7 +333,7 @@ class MultiTable:
             gretel_model=self._gretel_model,
             working_dir=str(self._working_dir),
             refresh_interval=self._refresh_interval,
-            artifact_collection=self._artifact_collection,
+            artifact_collection=replace(self._artifact_collection),
             relational_data=backup_relational_data,
         )
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -499,9 +499,7 @@ class MultiTable:
 
                     if rh_status == Status.COMPLETED:
                         self._log_success(table_name, "transforms data generation")
-                        out_table = pd.read_csv(
-                            record_handler.get_artifact_link("data"), compression="gzip"
-                        )
+                        out_table = _get_data_from_record_handler(record_handler)
                         output_tables[table_name] = out_table
                     elif rh_status in END_STATES:
                         self._log_failed(table_name, "transforms data generation")

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -891,10 +891,7 @@ class MultiTable:
         logger.warning(f"Lost contact with job for `{table_name}`.")
 
     def _validate_gretel_model(self, gretel_model: Optional[str]) -> Tuple[str, str]:
-        if gretel_model is None:
-            gretel_model = self._strategy.default_model
-        gretel_model = gretel_model.lower()
-
+        gretel_model = (gretel_model or self._strategy.default_model).lower()
         supported_models = self._strategy.supported_models
         if gretel_model not in supported_models:
             msg = f"Invalid gretel model requested: {gretel_model}. The selected strategy supports: {supported_models}."

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -315,6 +315,7 @@ class MultiTable:
             gretel_model=self._gretel_model,
             working_dir=str(self._working_dir),
             refresh_interval=self._refresh_interval,
+            artifact_collection=self._artifact_collection,
             relational_data=backup_relational_data,
         )
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -158,10 +158,10 @@ class MultiTable:
             raise MultiTableException(
                 "Cannot restore from backup—source table archive is missing."
             )
-        source_archive_path = working_dir / "synthetic_source_tables.tar.gz"
+        source_archive_path = working_dir / "synthetics_source_tables.tar.gz"
         _download_artifact(project, source_archive_id, source_archive_path)
         with tarfile.open(source_archive_path, "r:gz") as tar:
-            tar.extractall(working_dir)
+            tar.extractall()
 
         # Restore RelationalData instance
         rel_data = RelationalData()
@@ -280,7 +280,7 @@ class MultiTable:
                 project, synthetics_output_archive_id, synthetics_output_archive_path
             )
             with tarfile.open(synthetics_output_archive_path, "r:gz") as tar:
-                tar.extractall(working_dir)
+                tar.extractall()
             for table_name in backup.relational_data.tables:
                 local_synth_path = working_dir / f"synth_{table_name}.csv"
                 mt.synthetic_output_tables[table_name] = pd.read_csv(

--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -10,21 +10,8 @@ import pandas as pd
 from jinja2 import Environment, FileSystemLoader
 
 from gretel_trainer.relational.core import RelationalData, TableEvaluation
-from gretel_trainer.relational.multi_table import MultiTable
 
 _TEMPLATE_DIR = str(Path(__file__).parent)
-
-
-def create_report(multitable: MultiTable) -> None:
-    presenter = ReportPresenter(
-        rel_data=multitable.relational_data,
-        evaluations=multitable.evaluations,
-        now=datetime.datetime.utcnow(),
-    )
-    output_path = multitable._working_dir / "relational_report.html"
-    with open(output_path, "w") as report:
-        html_content = ReportRenderer().render(presenter)
-        report.write(html_content)
 
 
 class ReportRenderer:

--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -150,7 +150,18 @@ def _table_relationships(rel_data: RelationalData) -> Relationships:
 
 def _assign_primary_key_colors(rel_data: RelationalData) -> Dict[str, str]:
     colors = itertools.cycle(
-        ["#F48FB1", "#C5E1A5", "#FFCC80", "#CE93D8", "#FFF59D", "#90CAF9", "#FFE082", "#B39DDB", "#A5D6A7", "#80DEEA" ]
+        [
+            "#F48FB1",
+            "#C5E1A5",
+            "#FFCC80",
+            "#CE93D8",
+            "#FFF59D",
+            "#90CAF9",
+            "#FFE082",
+            "#B39DDB",
+            "#A5D6A7",
+            "#80DEEA",
+        ]
     )
     color_dict = {}
     for table in rel_data.list_all_tables():

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -1,6 +1,13 @@
-from typing import Dict
+import logging
+from pathlib import Path
+from typing import Dict, Union
 
+import requests
 from gretel_client.projects.jobs import Job, Status
+from gretel_client.projects.models import Model
+from gretel_client.projects.projects import Project
+
+logger = logging.getLogger(__name__)
 
 
 def cautiously_refresh_status(
@@ -13,3 +20,18 @@ def cautiously_refresh_status(
         refresh_attempts[key] = refresh_attempts[key] + 1
 
     return job.status
+
+
+def download_one_artifact(
+    gretel_object: Union[Project, Model],
+    artifact_name: str,
+    out_path: Union[str, Path],
+) -> None:
+    download_link = gretel_object.get_artifact_link(artifact_name)
+    try:
+        artifact = requests.get(download_link)
+        if artifact.status_code == 200:
+            with open(out_path, "wb+") as out:
+                out.write(artifact.content)
+    except requests.exceptions.HTTPError as ex:
+        logger.warning(f"Failed to download `{artifact_name}`")

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -1,6 +1,7 @@
 import logging
+from contextlib import suppress
 from pathlib import Path
-from typing import Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import requests
 import smart_open
@@ -45,3 +46,10 @@ def download_tar_artifact(project: Project, artifact_name: str, out_path: Path) 
                 out.write(response.content)
     except:
         logger.warning(f"Failed to download `{artifact_name}`")
+
+
+def sqs_score_from_full_report(report: Dict[str, Any]) -> Optional[int]:
+    with suppress(KeyError):
+        for field_dict in report["summary"]:
+            if field_dict["field"] == "synthetic_data_quality_score":
+                return field_dict["value"]

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -1,17 +1,6 @@
-from pathlib import Path
 from typing import Dict
 
-from gretel_client.projects import Project
 from gretel_client.projects.jobs import Job, Status
-
-
-def upload_singleton_project_artifact(project: Project, path: Path) -> str:
-    latest_key = project.upload_artifact(str(path))
-    for artifact in project.artifacts:
-        key = artifact["key"]
-        if key != latest_key and key.endswith(path.name):
-            project.delete_artifact(key)
-    return latest_key
 
 
 def cautiously_refresh_status(

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -191,7 +191,7 @@ class AncestralStrategy:
             seed_df = self._build_seed_data_for_table(
                 table, output_tables, rel_data, synth_size, training_columns
             )
-            seed_path = working_dir / f"seed_{table}.csv"
+            seed_path = working_dir / f"synthetics_seed_{table}.csv"
             seed_df.to_csv(seed_path, index=False)
             return {"data_source": str(seed_path)}
 

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -306,7 +306,8 @@ class AncestralStrategy:
         model: Model,
         working_dir: Path,
     ) -> None:
-        artifacts_dir = common.download_artifacts(model, table_name, working_dir)
+        out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
+        artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_sqs = common.get_sqs_score(model)
@@ -328,7 +329,8 @@ class AncestralStrategy:
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )
-        common.write_report(report, table, working_dir)
+        out_filepath = working_dir / f"synthetics_individual_evaluation_{table}"
+        common.write_report(report, out_filepath)
 
         evaluation.individual_sqs = report.peek().get("score")
         evaluation.individual_report_json = report.as_dict

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -12,6 +13,8 @@ from gretel_trainer.relational.core import (
     RelationalData,
     TableEvaluation,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class AncestralStrategy:
@@ -306,6 +309,7 @@ class AncestralStrategy:
         model: Model,
         working_dir: Path,
     ) -> None:
+        logger.info(f"Downloading cross_table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
         artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
 
@@ -326,6 +330,7 @@ class AncestralStrategy:
         source_data = rel_data.get_table_data(table)
         synth_data = synthetic_tables[table]
 
+        logger.info(f"Running individual evaluations for `{table}`.")
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -311,12 +311,12 @@ class AncestralStrategy:
     ) -> None:
         logger.info(f"Downloading cross_table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
-        artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
+        common.download_artifacts(model, out_filepath, table_name)
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_sqs = common.get_sqs_score(model)
         evaluation.cross_table_report_json = common.read_report_json_data(
-            model, artifacts_dir
+            model, out_filepath
         )
 
     def update_evaluation_via_evaluate(

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -34,9 +34,7 @@ def write_report(report: QualityReport, out_filepath: Path) -> None:
         f.write(json.dumps(report.as_dict))
 
 
-def download_artifacts(
-    model: Model, out_filepath: Path, table_name: str
-) -> Optional[Path]:
+def download_artifacts(model: Model, out_filepath: Path, table_name: str) -> None:
     """
     Downloads all model artifacts to a subdirectory in the working directory.
     Returns the artifact directory path when successful.
@@ -48,13 +46,11 @@ def download_artifacts(
         download_file_artifact(model, artifact_name, out_path)
 
 
-def read_report_json_data(
-    model: Model, artifacts_dir: Optional[Path]
-) -> Optional[Dict]:
-    if artifacts_dir is not None:
-        report_json_path = artifacts_dir / "report_json.json.gz"
-        return json.loads(smart_open.open(report_json_path).read())
-    else:
+def read_report_json_data(model: Model, report_path: Path) -> Optional[Dict]:
+    full_path = f"{report_path}.json"
+    try:
+        return json.loads(smart_open.open(full_path).read())
+    except:
         return _get_report_json(model)
 
 

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
 
 import pandas as pd
+import requests
 import smart_open
 from gretel_client.evaluation.quality_report import QualityReport
 from gretel_client.projects.models import Model
 from sklearn import preprocessing
 
 from gretel_trainer.relational.core import RelationalData
+from gretel_trainer.relational.sdk_extras import download_one_artifact
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +24,9 @@ def get_quality_report(
     return report
 
 
-def write_report(report: QualityReport, table_name: str, working_dir: Path) -> None:
-    html_path = working_dir / f"expanded_evaluation_{table_name}.html"
-    json_path = working_dir / f"expanded_evaluation_{table_name}.json"
+def write_report(report: QualityReport, out_filepath: Path) -> None:
+    html_path = f"{out_filepath}.html"
+    json_path = f"{out_filepath}.json"
 
     with open(html_path, "w") as f:
         f.write(report.as_html)
@@ -33,20 +35,19 @@ def write_report(report: QualityReport, table_name: str, working_dir: Path) -> N
 
 
 def download_artifacts(
-    model: Model, table_name: str, working_dir: Path
+    model: Model, out_filepath: Path, table_name: str
 ) -> Optional[Path]:
     """
     Downloads all model artifacts to a subdirectory in the working directory.
     Returns the artifact directory path when successful.
     """
-    target_dir = working_dir / f"artifacts_{table_name}"
-    logger.info(f"Downloading model artifacts for `{table_name}`")
-    try:
-        model.download_artifacts(target_dir)
-        return target_dir
-    except:
-        logger.warning(f"Failed to download model artifacts for {table_name}")
-        return None
+    logger.info(f"Downloading model evaluation artifacts for `{table_name}`")
+
+    legend = {"html": "report", "json": "report_json"}
+
+    for filetype, artifact_name in legend.items():
+        out_path = f"{out_filepath}.{filetype}"
+        download_one_artifact(model, artifact_name, out_path)
 
 
 def read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -41,8 +41,6 @@ def download_artifacts(
     Downloads all model artifacts to a subdirectory in the working directory.
     Returns the artifact directory path when successful.
     """
-    logger.info(f"Downloading model evaluation artifacts for `{table_name}`")
-
     legend = {"html": "report", "json": "report_json"}
 
     for filetype, artifact_name in legend.items():

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -11,7 +11,7 @@ from gretel_client.projects.models import Model
 from sklearn import preprocessing
 
 from gretel_trainer.relational.core import RelationalData
-from gretel_trainer.relational.sdk_extras import download_one_artifact
+from gretel_trainer.relational.sdk_extras import download_file_artifact
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def download_artifacts(
 
     for filetype, artifact_name in legend.items():
         out_path = f"{out_filepath}.{filetype}"
-        download_one_artifact(model, artifact_name, out_path)
+        download_file_artifact(model, artifact_name, out_path)
 
 
 def read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -8,6 +9,8 @@ from gretel_client.projects.models import Model
 import gretel_trainer.relational.ancestry as ancestry
 import gretel_trainer.relational.strategies.common as common
 from gretel_trainer.relational.core import RelationalData, TableEvaluation
+
+logger = logging.getLogger(__name__)
 
 
 class IndependentStrategy:
@@ -139,6 +142,7 @@ class IndependentStrategy:
         model: Model,
         working_dir: Path,
     ) -> None:
+        logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
         artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
 
@@ -161,6 +165,7 @@ class IndependentStrategy:
             rel_data, table, synthetic_tables
         )
 
+        logger.info(f"Running cross_table evaluations for `{table}`.")
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -139,7 +139,8 @@ class IndependentStrategy:
         model: Model,
         working_dir: Path,
     ) -> None:
-        artifacts_dir = common.download_artifacts(model, table_name, working_dir)
+        out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
+        artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
 
         evaluation = evaluations[table_name]
         evaluation.individual_sqs = common.get_sqs_score(model)
@@ -163,7 +164,8 @@ class IndependentStrategy:
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )
-        common.write_report(report, table, working_dir)
+        out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table}"
+        common.write_report(report, out_filepath)
 
         evaluation.cross_table_sqs = report.peek().get("score")
         evaluation.cross_table_report_json = report.as_dict

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -144,12 +144,12 @@ class IndependentStrategy:
     ) -> None:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
-        artifacts_dir = common.download_artifacts(model, out_filepath, table_name)
+        common.download_artifacts(model, out_filepath, table_name)
 
         evaluation = evaluations[table_name]
         evaluation.individual_sqs = common.get_sqs_score(model)
         evaluation.individual_report_json = common.read_report_json_data(
-            model, artifacts_dir
+            model, out_filepath
         )
 
     def update_evaluation_via_evaluate(

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -1,4 +1,3 @@
-import gzip
 import json
 import os
 import tempfile
@@ -402,11 +401,10 @@ def test_uses_trained_model_to_update_cross_table_scores():
     ) as get_sqs:
         get_sqs.return_value = 80
         working_dir = Path(working_dir)
-        artifacts_subdir = working_dir / "artifacts_table_1"
-        os.makedirs(artifacts_subdir, exist_ok=True)
-        with gzip.open(str(artifacts_subdir / "report_json.json.gz"), "wb") as f:
-            f.write(b'{"report": "json"}')
-        download_artifacts.return_value = artifacts_subdir
+        with open(
+            working_dir / "synthetics_cross_table_evaluation_table_1.json", "w"
+        ) as f:
+            f.write(json.dumps({"report": "json"}))
 
         strategy.update_evaluation_from_model(
             "table_1", evaluations, model, working_dir

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -481,11 +481,15 @@ def test_updates_single_table_scores_using_evaluate(source_nba, synthetic_nba):
         )
         assert len(os.listdir(working_dir)) == 2
         assert (
-            smart_open.open(working_dir / "expanded_evaluation_cities.html").read()
+            smart_open.open(
+                working_dir / "synthetics_individual_evaluation_cities.html"
+            ).read()
             == "HTML"
         )
         assert json.loads(
-            smart_open.open(working_dir / "expanded_evaluation_cities.json").read()
+            smart_open.open(
+                working_dir / "synthetics_individual_evaluation_cities.json"
+            ).read()
         ) == {"REPORT": "JSON"}
 
     get_report.assert_called_once_with(

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -46,11 +46,9 @@ def test_backup():
         tables={
             "customer": BackupGenerateTable(
                 record_handler_id="555444666",
-                synthetic_artifact_id="gretel_boaief_synth_customer.csv",
             ),
             "address": BackupGenerateTable(
                 record_handler_id="333111222",
-                synthetic_artifact_id=None,
             ),
         },
     )

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -55,7 +55,7 @@ def test_backup():
     )
     artifact_collection = ArtifactCollection(
         gretel_debug_summary="gretel_abc__gretel_debug_summary.json",
-        synthetics_source_archive="gretel_abc_synthetics_source_tables.tar.gz",
+        source_archive="gretel_abc_source_tables.tar.gz",
     )
     backup = Backup(
         project_name="my-project",

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -16,11 +16,9 @@ def test_backup():
     backup_relational = BackupRelationalData(
         tables={
             "customer": BackupRelationalDataTable(
-                source_artifact_id="gretel_abcdefg_customer.csv",
                 primary_key="id",
             ),
             "address": BackupRelationalDataTable(
-                source_artifact_id="gretel_abcdefg_address.csv",
                 primary_key=None,
             ),
         },

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -54,9 +54,8 @@ def test_backup():
         },
     )
     artifact_collection = ArtifactCollection(
-        gretel_backup="gretel_abc__gretel_backup.json",
         gretel_debug_summary="gretel_abc__gretel_debug_summary.json",
-        synthetics_output_archive="gretel_abc_synthetics_output_tables.tar.gz",
+        synthetics_source_archive="gretel_abc_synthetics_source_tables.tar.gz",
     )
     backup = Backup(
         project_name="my-project",

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -1,5 +1,6 @@
 import json
 
+from gretel_trainer.relational.artifacts import ArtifactCollection
 from gretel_trainer.relational.backup import (
     Backup,
     BackupForeignKey,
@@ -52,12 +53,18 @@ def test_backup():
             ),
         },
     )
+    artifact_collection = ArtifactCollection(
+        gretel_backup="gretel_abc__gretel_backup.json",
+        gretel_debug_summary="gretel_abc__gretel_debug_summary.json",
+        synthetics_output_archive="gretel_abc_synthetics_output_tables.tar.gz",
+    )
     backup = Backup(
         project_name="my-project",
         strategy="independent",
         gretel_model="amplify",
         working_dir="workdir",
         refresh_interval=120,
+        artifact_collection=artifact_collection,
         relational_data=backup_relational,
         train=backup_train,
         generate=backup_generate,

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -1,4 +1,3 @@
-import gzip
 import json
 import os
 import tempfile
@@ -182,11 +181,10 @@ def test_uses_trained_model_to_update_individual_scores():
     ) as get_sqs:
         get_sqs.return_value = 80
         working_dir = Path(working_dir)
-        artifacts_subdir = working_dir / "artifacts_table_1"
-        os.makedirs(artifacts_subdir, exist_ok=True)
-        with gzip.open(str(artifacts_subdir / "report_json.json.gz"), "wb") as f:
-            f.write(b'{"report": "json"}')
-        download_artifacts.return_value = artifacts_subdir
+        with open(
+            working_dir / "synthetics_individual_evaluation_table_1.json", "w"
+        ) as f:
+            f.write(json.dumps({"report": "json"}))
 
         strategy.update_evaluation_from_model(
             "table_1", evaluations, model, working_dir

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -261,11 +261,15 @@ def test_updates_cross_table_scores_using_evaluate(source_nba, synthetic_nba):
         )
         assert len(os.listdir(working_dir)) == 2
         assert (
-            smart_open.open(working_dir / "expanded_evaluation_cities.html").read()
+            smart_open.open(
+                working_dir / "synthetics_cross_table_evaluation_cities.html"
+            ).read()
             == "HTML"
         )
         assert json.loads(
-            smart_open.open(working_dir / "expanded_evaluation_cities.json").read()
+            smart_open.open(
+                working_dir / "synthetics_cross_table_evaluation_cities.json"
+            ).read()
         ) == {"REPORT": "JSON"}
 
     get_report.assert_called_once()

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -12,7 +12,11 @@ from gretel_trainer.relational.strategies.independent import IndependentStrategy
 def test_model_strategy_combinations(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
+    ), patch(
+        "gretel_trainer.relational.multi_table.create_project"
+    ) as create_project, patch(
+        "gretel_trainer.relational.artifacts.ArtifactCollection.upload_gretel_backup"
+    ):
         project = Mock()
         project.name = tmpdir
         project.upload_artifact.return_value = "gretel_abcdefg_somefile.someextension"
@@ -68,7 +72,11 @@ def test_model_strategy_combinations(ecom):
 def test_refresh_interval_config(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
+    ), patch(
+        "gretel_trainer.relational.multi_table.create_project"
+    ) as create_project, patch(
+        "gretel_trainer.relational.artifacts.ArtifactCollection.upload_gretel_backup"
+    ):
         project = Mock()
         project.name = tmpdir
         project.upload_artifact.return_value = "gretel_abcdefg_somefile.someextension"

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -15,7 +15,7 @@ def test_model_strategy_combinations(ecom):
     ), patch(
         "gretel_trainer.relational.multi_table.create_project"
     ) as create_project, patch(
-        "gretel_trainer.relational.artifacts.ArtifactCollection.upload_gretel_backup"
+        "gretel_trainer.relational.multi_table._upload_gretel_backup"
     ):
         project = Mock()
         project.name = tmpdir
@@ -75,7 +75,7 @@ def test_refresh_interval_config(ecom):
     ), patch(
         "gretel_trainer.relational.multi_table.create_project"
     ) as create_project, patch(
-        "gretel_trainer.relational.artifacts.ArtifactCollection.upload_gretel_backup"
+        "gretel_trainer.relational.multi_table._upload_gretel_backup"
     ):
         project = Mock()
         project.name = tmpdir

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -12,15 +12,11 @@ from gretel_trainer.relational.strategies.independent import IndependentStrategy
 def test_model_strategy_combinations(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch(
-        "gretel_trainer.relational.multi_table.create_project"
-    ) as create_project, patch(
-        "gretel_trainer.relational.multi_table.upload_singleton_project_artifact"
-    ) as upload_singleton:
+    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
         project = Mock()
         project.name = tmpdir
+        project.upload_artifact.return_value = "gretel_abcdefg_somefile.someextension"
         create_project.return_value = project
-        upload_singleton.return_value = "gretel_abcdefg_source_table.csv"
 
         # Default to Amplify/single-table
         mt = MultiTable(ecom, project_display_name=tmpdir)
@@ -72,15 +68,11 @@ def test_model_strategy_combinations(ecom):
 def test_refresh_interval_config(ecom):
     with tempfile.TemporaryDirectory() as tmpdir, patch(
         "gretel_trainer.relational.multi_table.configure_session"
-    ), patch(
-        "gretel_trainer.relational.multi_table.create_project"
-    ) as create_project, patch(
-        "gretel_trainer.relational.multi_table.upload_singleton_project_artifact"
-    ) as upload_singleton:
+    ), patch("gretel_trainer.relational.multi_table.create_project") as create_project:
         project = Mock()
         project.name = tmpdir
+        project.upload_artifact.return_value = "gretel_abcdefg_somefile.someextension"
         create_project.return_value = project
-        upload_singleton.return_value = "gretel_abcdefg_source_table.csv"
 
         # default to 180
         mt = MultiTable(ecom, project_display_name=tmpdir)


### PR DESCRIPTION
- Leverages the new support for tar.gz archive files as project artifacts to revamp how we manage relational artifacts:
```diff
- (N) source_{table}.csv
+ (1) source_tables.tar.gz

- (N) synth_{table}.csv
+ (1) synthetics_outputs.tar.gz
# Includes all synthetic output tables + all reports (individual and cross-table; html and json) + relational report (html)
```

- Renames evaluation outputs to better express their contents
```diff
- artifacts_{table}/  # subdir with report html, report json, logs
- expanded_evaluations_{table}.[html|json]
+ synthetics_cross_table_evaluation_{table}.[html|json]
+ synthetics_individual_evaluation_{table}.[html|json]
```

- Evaluation results (reports, scores) are now included in the restore process.

- Automatically run QualityReports/Evaluate for each table + create the relational report at the end of generate. This means users don't need to call `expand_evaluations` manually anymore (I've made it a private method, should be removed from examples/docs). Also the `create_report(multitable)` function is deprecated in favor of `multitable.create_relational_report()`.

- Small interface change to `MultiTable.init` that shouldn't affect users: instead of the restore workflow passing `project_unique_name`, we now pass a `restore_config` object (which includes the unique name + other data we need). The restore method constructs this config for you via the backup info, so you shouldn't ever need to make one and pass this argument yourself. (To consider: this does allow us to "un-deprecate" the `project_name` param; let's decide if we want to do that or keep the current/newer `project_display_name`.)