### PR TITLE
Fast follow

### DIFF
--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -172,7 +172,7 @@
     "    # project_display_name=\"multi-table\",\n",
     "    # gretel_model=\"amplify\",\n",
     "    # strategy=\"independent\",\n",
-    "    # refresh_interval=180,\n",
+    "    # refresh_interval=60,\n",
     ")"
    ]
   },
@@ -220,20 +220,6 @@
    "metadata": {},
    "source": [
     "#### Synthetics"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Throughout the synthetics process, there are a few ways to inspect the overall state\n",
-    "\n",
-    "multitable.train_statuses\n",
-    "multitable.generate_statuses\n",
-    "multitable.state_by_action\n",
-    "multitable.state_by_table"
    ]
   },
   {
@@ -433,7 +419,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10 (main, May 17 2022, 13:39:35) \n[Clang 13.1.6 (clang-1316.0.21.2.5)]"
+   "version": "3.9.10"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -51,6 +51,8 @@ from gretel_trainer.relational.strategies.independent import IndependentStrategy
 
 GretelModelConfig = Union[str, Path, Dict]
 
+MAX_REFRESH_ATTEMPTS = 3
+
 logger = logging.getLogger(__name__)
 
 
@@ -528,7 +530,7 @@ class MultiTable:
                     continue
 
                 # If we consistently failed to refresh the job status, fail the table
-                if refresh_attempts[table_name] >= 5:
+                if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     record_handler_statuses[table_name] = Status.LOST
                     continue
@@ -634,7 +636,7 @@ class MultiTable:
                     continue
 
                 # If we consistently failed to refresh the job status, fail the table
-                if refresh_attempts[table_name] >= 5:
+                if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     self.train_statuses[table_name] = TrainStatus.Failed
                     continue
@@ -783,7 +785,7 @@ class MultiTable:
                     continue
 
                 # If we consistently failed to refresh the job via API, fail the table
-                if refresh_attempts[table_name] >= 5:
+                if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     self.generate_statuses[table_name] = GenerateStatus.Failed
                     continue

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -550,7 +550,9 @@ class MultiTable:
                     elif rh_status in END_STATES:
                         self._log_failed(table_name, "transforms data generation")
                     else:
-                        self._log_in_progress(table_name, "transforms data generation")
+                        self._log_in_progress(
+                            table_name, rh_status, "transforms data generation"
+                        )
 
                     continue
 
@@ -574,7 +576,9 @@ class MultiTable:
                     # In this case, CANCELLED is standing in for "Won't Attempt"
                     record_handler_statuses[table_name] = Status.CANCELLED
                 else:
-                    self._log_in_progress(table_name, "transforms model training")
+                    self._log_in_progress(
+                        table_name, model_status, "transforms model training"
+                    )
 
         return output_tables
 
@@ -656,7 +660,7 @@ class MultiTable:
                     self._log_failed(table_name, "model training")
                     self.train_statuses[table_name] = TrainStatus.Failed
                 else:
-                    self._log_in_progress(table_name, "model training")
+                    self._log_in_progress(table_name, status, "model training")
                     continue
 
             self._backup()
@@ -810,7 +814,9 @@ class MultiTable:
                     self._log_failed(table_name, "synthetic data generation")
                     self.generate_statuses[table_name] = GenerateStatus.Failed
                 else:
-                    self._log_in_progress(table_name, "synthetic data generation")
+                    self._log_in_progress(
+                        table_name, status, "synthetic data generation"
+                    )
                     continue
 
             # Determine if we can start any more jobs
@@ -979,8 +985,10 @@ class MultiTable:
     def _log_start(self, table_name: str, action: str) -> None:
         logger.info(f"Starting {action} for `{table_name}`.")
 
-    def _log_in_progress(self, table_name: str, action: str) -> None:
-        logger.info(f"{action.capitalize()} job for `{table_name}` still in progress.")
+    def _log_in_progress(self, table_name: str, status: Status, action: str) -> None:
+        logger.info(
+            f"{action.capitalize()} job for `{table_name}` still in progress (status: {status})."
+        )
 
     def _log_failed(self, table_name: str, action: str) -> None:
         logger.info(f"{action.capitalize()} failed for `{table_name}`.")

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -105,7 +105,7 @@ class MultiTable:
         strategy (str, optional): The strategy to use. Supports "independent" (default) and "ancestral".
         gretel_model (str, optional): The underlying Gretel model to use. Default and acceptable models vary based on strategy.
         project_display_name (str, optional): Display name in the console for a new Gretel project holding models and artifacts. Defaults to "multi-table".
-        refresh_interval (int, optional): Frequency in seconds to poll Gretel Cloud for job statuses. Must be at least 60 (1m). Defaults to 180 (3m).
+        refresh_interval (int, optional): Frequency in seconds to poll Gretel Cloud for job statuses. Must be at least 30. Defaults to 60 (1m).
         restore_config (RestoreConfig, optional): Data used to restore from backup. Should not be supplied manually; instead use the `restore` classmethod.
     """
 
@@ -435,13 +435,13 @@ class MultiTable:
 
     def _set_refresh_interval(self, interval: Optional[int]) -> None:
         if interval is None:
-            self._refresh_interval = 180
+            self._refresh_interval = 60
         else:
-            if interval < 60:
+            if interval < 30:
                 logger.warning(
-                    "Refresh interval must be at least 60 seconds. Setting to 60."
+                    "Refresh interval must be at least 30 seconds. Setting to 30."
                 )
-                self._refresh_interval = 60
+                self._refresh_interval = 30
             else:
                 self._refresh_interval = interval
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -415,26 +415,6 @@ class MultiTable:
 
         return backup
 
-    @property
-    def state_by_action(self) -> Dict[str, Dict[str, Any]]:
-        return {
-            "train": self.train_statuses,
-            "generate": self.generate_statuses,
-        }
-
-    @property
-    def state_by_table(self) -> Dict[str, Dict[str, Any]]:
-        return {
-            table_name: self._table_state(table_name)
-            for table_name in self.relational_data.list_all_tables()
-        }
-
-    def _table_state(self, table_name: str) -> Dict[str, Any]:
-        return {
-            "train": self.train_statuses[table_name],
-            "generate": self.generate_statuses[table_name],
-        }
-
     def _set_refresh_interval(self, interval: Optional[int]) -> None:
         if interval is None:
             self._refresh_interval = 60

--- a/tests/relational/test_multi_table.py
+++ b/tests/relational/test_multi_table.py
@@ -82,14 +82,14 @@ def test_refresh_interval_config(ecom):
         project.upload_artifact.return_value = "gretel_abcdefg_somefile.someextension"
         create_project.return_value = project
 
-        # default to 180
+        # default to 60
         mt = MultiTable(ecom, project_display_name=tmpdir)
-        assert mt._refresh_interval == 180
-
-        # must be at least 60
-        mt = MultiTable(ecom, project_display_name=tmpdir, refresh_interval=30)
         assert mt._refresh_interval == 60
 
-        # may be greater than 60
-        mt = MultiTable(ecom, project_display_name=tmpdir, refresh_interval=120)
-        assert mt._refresh_interval == 120
+        # must be at least 30
+        mt = MultiTable(ecom, project_display_name=tmpdir, refresh_interval=20)
+        assert mt._refresh_interval == 30
+
+        # may be greater than 30
+        mt = MultiTable(ecom, project_display_name=tmpdir, refresh_interval=45)
+        assert mt._refresh_interval == 45


### PR DESCRIPTION
- Reduce max retry count on lost-ish jobs from 5 to 3
- Reduce minimum refresh interval to 30s, default to 60s
- Add job status (created/active/pending) to in-progress log statement
- Drop `state_by_[action|table]` methods