### PR TITLE
Restore fixes

### DIFF
--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -570,9 +570,10 @@ class MultiTable:
         archive_path = self._working_dir / "transforms_outputs.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
             for table, df in output_tables.items():
-                out_path = self._working_dir / f"transformed_{table}.csv"
+                filename = f"transformed_{table}.csv"
+                out_path = self._working_dir / filename
                 df.to_csv(out_path, index=False)
-                tar.add(out_path)
+                tar.add(out_path, arcname=filename)
 
         self._artifact_collection.upload_transforms_outputs_archive(
             self._project, str(archive_path)
@@ -694,10 +695,11 @@ class MultiTable:
         archive_path = self._working_dir / "source_tables.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
             for table in self.relational_data.list_all_tables():
-                out_path = self._working_dir / f"source_{table}.csv"
+                filename = f"source_{table}.csv"
+                out_path = self._working_dir / filename
                 df = self.relational_data.get_table_data(table)
                 df.to_csv(out_path, index=False)
-                tar.add(out_path)
+                tar.add(out_path, arcname=filename)
         self._artifact_collection.upload_source_archive(
             self._project, str(archive_path)
         )
@@ -883,19 +885,23 @@ class MultiTable:
 
         archive_path = self._working_dir / "synthetics_outputs.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(self._working_dir / "relational_report.html")
+            tar.add(
+                self._working_dir / "relational_report.html",
+                arcname="relational_report.html",
+            )
             for table in self.relational_data.list_all_tables():
                 # Add synthetic output table
                 synthetic_df = output_tables[table]
-                out_path = self._working_dir / f"synth_{table}.csv"
+                filename = f"synth_{table}.csv"
+                out_path = self._working_dir / filename
                 synthetic_df.to_csv(out_path, index=False)
-                tar.add(out_path)
+                tar.add(out_path, arcname=filename)
                 # Add individual and cross_table reports
                 for eval_type in ["individual", "cross_table"]:
                     for ext in ["html", "json"]:
                         filename = f"synthetics_{eval_type}_evaluation_{table}.{ext}"
                         try:
-                            tar.add(self._working_dir / filename)
+                            tar.add(self._working_dir / filename, arcname=filename)
                         except FileNotFoundError:
                             logger.warning(
                                 f"Could not find `{filename}` in working directory"

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -154,7 +154,7 @@ class MultiTable:
         logger.info(
             f"Connected to existing project `{self._project.display_name}` with unique name `{self._project.name}`."
         )
-        self._working_dir = Path(backup.working_dir)
+        self._working_dir = _mkdir(backup.working_dir)
         self._artifact_collection = backup.artifact_collection
 
         # RelationalData

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -150,7 +150,7 @@ class MultiTable:
 
     def _complete_init_from_backup(self, backup: Backup) -> None:
         # Raises GretelProjectEror if not found
-        self._project = get_project(backup.project_name)
+        self._project = get_project(name=backup.project_name)
         logger.info(
             f"Connected to existing project `{self._project.display_name}` with unique name `{self._project.name}`."
         )


### PR DESCRIPTION
- Fix missing keyword arg to `get_project`
- Prevent nested files in archives—add all files at archive root level
- Create working dir during restore if it doesn't exist (e.g. loading backup file from some other location)