### PR TITLE
Preprocessing updates

### DIFF
--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -52,19 +52,13 @@ class AncestralStrategy:
 
         # Create a new table set identical to source data
         for table_name in all_tables:
-            altered_tableset[table_name] = rel_data.get_table_data(
-                table_name
-            ).copy()
+            altered_tableset[table_name] = rel_data.get_table_data(table_name).copy()
 
         # Translate all keys to a contiguous list of integers
-        altered_tableset = common.label_encode_keys(
-            rel_data, altered_tableset
-        )
+        altered_tableset = common.label_encode_keys(rel_data, altered_tableset)
 
         # Add artificial rows to support seeding
-        altered_tableset = _add_artifical_rows_for_seeding(
-            rel_data, altered_tableset
-        )
+        altered_tableset = _add_artifical_rows_for_seeding(rel_data, altered_tableset)
 
         # Collect all data in multigenerational format
         for table_name in all_tables:

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -51,7 +51,7 @@ class AncestralStrategy:
 
         # First, create a new table set identical to source data
         for table_name in all_tables:
-            tableset_with_altered_keys[table_name] = rel_data.get_table_data(table_name)
+            tableset_with_altered_keys[table_name] = rel_data.get_table_data(table_name).copy()
 
         # On each table, alter the PKs in the first two rows for the
         # min/max seed range, plus alter all FK references to those records

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -65,7 +65,7 @@ class AncestralStrategy:
 
             max_pk_values[table_name] = len(data) * 50
 
-            last_record_copy = tableset_with_altered_keys[table_name].tail(1).copy()
+            last_record_copy = tableset_with_altered_keys[table_name].sample().copy()
             last_record_copy[pk] = max_pk_values[table_name]
             tableset_with_altered_keys[table_name] = pd.concat([data, last_record_copy]).reset_index(drop=True)
 
@@ -77,17 +77,17 @@ class AncestralStrategy:
 
             pk = rel_data.get_primary_key(table_name)
 
-            artificial_record = tableset_with_altered_keys[table_name].tail(1)
-            min_fk_record = artificial_record.copy()
-            max_fk_record = artificial_record.copy()
+            two_records = tableset_with_altered_keys[table_name].sample(2)
+            min_fk_record = two_records.head(1).copy()
+            max_fk_record = two_records.tail(1).copy()
 
             for foreign_key in foreign_keys:
                 min_fk_record[foreign_key.column_name] = 0
                 max_fk_record[foreign_key.column_name] = max_pk_values[foreign_key.parent_table_name]
 
-                if pk is not None:
-                    min_fk_record[pk] = max_pk_values[table_name] + 1
-                    max_fk_record[pk] = max_pk_values[table_name] + 2
+            if pk is not None:
+                min_fk_record[pk] = max_pk_values[table_name] + 1
+                max_fk_record[pk] = max_pk_values[table_name] + 2
 
             tableset_with_altered_keys[table_name] = pd.concat([data, min_fk_record, max_fk_record]).reset_index(drop=True)
 

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -51,10 +51,14 @@ class AncestralStrategy:
 
         # First, create a new table set identical to source data
         for table_name in all_tables:
-            tableset_with_altered_keys[table_name] = rel_data.get_table_data(table_name).copy()
+            tableset_with_altered_keys[table_name] = rel_data.get_table_data(
+                table_name
+            ).copy()
 
         # Translate all PKs to a contiguous list of integers
-        tableset_with_altered_keys = common.label_encode_keys(rel_data, tableset_with_altered_keys)
+        tableset_with_altered_keys = common.label_encode_keys(
+            rel_data, tableset_with_altered_keys
+        )
 
         # On each table, add an artifical row with the max possible PK value
         max_pk_values = {}
@@ -67,7 +71,9 @@ class AncestralStrategy:
 
             last_record_copy = tableset_with_altered_keys[table_name].sample().copy()
             last_record_copy[pk] = max_pk_values[table_name]
-            tableset_with_altered_keys[table_name] = pd.concat([data, last_record_copy]).reset_index(drop=True)
+            tableset_with_altered_keys[table_name] = pd.concat(
+                [data, last_record_copy]
+            ).reset_index(drop=True)
 
         # On each table with foreign keys, add two more artificial rows containing the min and max FK values
         for table_name, data in tableset_with_altered_keys.items():
@@ -83,13 +89,17 @@ class AncestralStrategy:
 
             for foreign_key in foreign_keys:
                 min_fk_record[foreign_key.column_name] = 0
-                max_fk_record[foreign_key.column_name] = max_pk_values[foreign_key.parent_table_name]
+                max_fk_record[foreign_key.column_name] = max_pk_values[
+                    foreign_key.parent_table_name
+                ]
 
             if pk is not None:
                 min_fk_record[pk] = max_pk_values[table_name] + 1
                 max_fk_record[pk] = max_pk_values[table_name] + 2
 
-            tableset_with_altered_keys[table_name] = pd.concat([data, min_fk_record, max_fk_record]).reset_index(drop=True)
+            tableset_with_altered_keys[table_name] = pd.concat(
+                [data, min_fk_record, max_fk_record]
+            ).reset_index(drop=True)
 
         # Next, collect all data in multigenerational format
         for table_name in all_tables:

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -39,76 +39,41 @@ class AncestralStrategy:
         self, rel_data: RelationalData
     ) -> Dict[str, pd.DataFrame]:
         """
-        Returns tables with all ancestor fields added,
-        minus any highly-unique categorical fields from ancestors.
-        Primary keys are modified on two records to accommodate a
-        sufficiently wide range of synthetic values during seeding.
-        Corresponding foreign keys are also modified accordingly.
+        Returns tables with:
+        - all ancestor fields added
+        - columns in multigenerational format
+        - all keys translated to contiguous integers
+        - artificial min/max seed records added
+        - known-problematic fields removed
         """
         all_tables = rel_data.list_all_tables()
-        tableset_with_altered_keys = {}
+        altered_tableset = {}
         training_data = {}
 
-        # First, create a new table set identical to source data
+        # Create a new table set identical to source data
         for table_name in all_tables:
-            tableset_with_altered_keys[table_name] = rel_data.get_table_data(
+            altered_tableset[table_name] = rel_data.get_table_data(
                 table_name
             ).copy()
 
-        # Translate all PKs to a contiguous list of integers
-        tableset_with_altered_keys = common.label_encode_keys(
-            rel_data, tableset_with_altered_keys
+        # Translate all keys to a contiguous list of integers
+        altered_tableset = common.label_encode_keys(
+            rel_data, altered_tableset
         )
 
-        # On each table, add an artifical row with the max possible PK value
-        max_pk_values = {}
-        for table_name, data in tableset_with_altered_keys.items():
-            pk = rel_data.get_primary_key(table_name)
-            if pk is None:
-                continue
+        # Add artificial rows to support seeding
+        altered_tableset = _add_artifical_rows_for_seeding(
+            rel_data, altered_tableset
+        )
 
-            max_pk_values[table_name] = len(data) * 50
-
-            last_record_copy = tableset_with_altered_keys[table_name].sample().copy()
-            last_record_copy[pk] = max_pk_values[table_name]
-            tableset_with_altered_keys[table_name] = pd.concat(
-                [data, last_record_copy]
-            ).reset_index(drop=True)
-
-        # On each table with foreign keys, add two more artificial rows containing the min and max FK values
-        for table_name, data in tableset_with_altered_keys.items():
-            foreign_keys = rel_data.get_foreign_keys(table_name)
-            if len(foreign_keys) == 0:
-                continue
-
-            pk = rel_data.get_primary_key(table_name)
-
-            two_records = tableset_with_altered_keys[table_name].sample(2)
-            min_fk_record = two_records.head(1).copy()
-            max_fk_record = two_records.tail(1).copy()
-
-            for foreign_key in foreign_keys:
-                min_fk_record[foreign_key.column_name] = 0
-                max_fk_record[foreign_key.column_name] = max_pk_values[
-                    foreign_key.parent_table_name
-                ]
-
-            if pk is not None:
-                min_fk_record[pk] = max_pk_values[table_name] + 1
-                max_fk_record[pk] = max_pk_values[table_name] + 2
-
-            tableset_with_altered_keys[table_name] = pd.concat(
-                [data, min_fk_record, max_fk_record]
-            ).reset_index(drop=True)
-
-        # Next, collect all data in multigenerational format
+        # Collect all data in multigenerational format
         for table_name in all_tables:
             data = ancestry.get_table_data_with_ancestors(
-                rel_data, table_name, tableset_with_altered_keys
+                rel_data, table_name, altered_tableset
             )
             training_data[table_name] = data
 
-        # Finally, drop highly-unique categorical ancestor fields
+        # Drop some columns known to be problematic
         for table_name, data in training_data.items():
             columns_to_drop = [
                 col for col in data.columns if _drop_from_training(col, data)
@@ -345,6 +310,51 @@ class AncestralStrategy:
 
         evaluation.individual_sqs = report.peek().get("score")
         evaluation.individual_report_json = report.as_dict
+
+
+def _add_artifical_rows_for_seeding(
+    rel_data: RelationalData, tables: Dict[str, pd.DataFrame]
+) -> Dict[str, pd.DataFrame]:
+    # On each table, add an artifical row with the max possible PK value
+    max_pk_values = {}
+    for table_name, data in tables.items():
+        pk = rel_data.get_primary_key(table_name)
+        if pk is None:
+            continue
+
+        max_pk_values[table_name] = len(data) * 50
+
+        random_record = tables[table_name].sample().copy()
+        random_record[pk] = max_pk_values[table_name]
+        tables[table_name] = pd.concat([data, random_record]).reset_index(drop=True)
+
+    # On each table with foreign keys, add two more artificial rows containing the min and max FK values
+    for table_name, data in tables.items():
+        foreign_keys = rel_data.get_foreign_keys(table_name)
+        if len(foreign_keys) == 0:
+            continue
+
+        pk = rel_data.get_primary_key(table_name)
+
+        two_records = tables[table_name].sample(2)
+        min_fk_record = two_records.head(1).copy()
+        max_fk_record = two_records.tail(1).copy()
+
+        for foreign_key in foreign_keys:
+            min_fk_record[foreign_key.column_name] = 0
+            max_fk_record[foreign_key.column_name] = max_pk_values[
+                foreign_key.parent_table_name
+            ]
+
+        if pk is not None:
+            min_fk_record[pk] = max_pk_values[table_name] + 1
+            max_fk_record[pk] = max_pk_values[table_name] + 2
+
+        tables[table_name] = pd.concat(
+            [data, min_fk_record, max_fk_record]
+        ).reset_index(drop=True)
+
+    return tables
 
 
 def _drop_from_training(col: str, df: pd.DataFrame) -> bool:

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -69,6 +69,11 @@ def mutagenesis() -> RelationalData:
 
 
 @pytest.fixture()
+def art() -> RelationalData:
+    return rel_data_from_example_db("art")
+
+
+@pytest.fixture()
 def trips() -> RelationalData:
     rel_data = rel_data_from_example_db("trips")
     rel_data.update_table_data(

--- a/tests/relational/example_dbs/art.sql
+++ b/tests/relational/example_dbs/art.sql
@@ -1,0 +1,29 @@
+create table if not exists artists (
+  id text primary key,
+  name text not null
+);
+delete from artists;
+
+create table if not exists paintings (
+  id text primary key,
+  name text not null,
+  artist_id text not null,
+  --
+  foreign key (artist_id) references artists (id)
+);
+delete from paintings;
+
+insert into artists (id, name) values
+  ("A001", "Wassily Kandinsky"),
+  ("A002", "Pablo Picasso"),
+  ("A003", "Vincent van Gogh"),
+  ("A004", "Leonardo da Vinci");
+
+insert into paintings (id, artist_id, name) values
+  ("P001", "A004", "Mona Lisa"),
+  ("P002", "A004", "The Last Supper"),
+  ("P004", "A002", "Guernica"),
+  ("P005", "A002", "The Old Guitarist"),
+  ("P006", "A003", "Starry Night"),
+  ("P007", "A003", "Bedroom in Arles"),
+  ("P008", "A003", "Irises");

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -14,6 +14,22 @@ from gretel_trainer.relational.core import MultiTableException, TableEvaluation
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 
 
+def test_preparing_training_data_does_not_mutate_source_data(pets, art):
+    for rel_data in [pets, art]:
+        original_tables = {
+            table: rel_data.get_table_data(table).copy()
+            for table in rel_data.list_all_tables()
+        }
+
+        strategy = AncestralStrategy()
+        strategy.prepare_training_data(rel_data)
+
+        for table in rel_data.list_all_tables():
+            pdtest.assert_frame_equal(
+                original_tables[table], rel_data.get_table_data(table)
+            )
+
+
 def test_prepare_training_data_returns_multigenerational_data(pets):
     strategy = AncestralStrategy()
 
@@ -29,22 +45,6 @@ def test_prepare_training_data_drops_highly_unique_categorical_ancestor_fields()
 
 def test_prepare_training_data_drops_highly_nan_ancestor_fields():
     pass
-
-
-def test_preparing_training_data_does_not_mutate_source_data(pets, art):
-    for rel_data in [pets, art]:
-        original_tables = {
-            table: rel_data.get_table_data(table).copy()
-            for table in rel_data.list_all_tables()
-        }
-
-        strategy = AncestralStrategy()
-        strategy.prepare_training_data(rel_data)
-
-        for table in rel_data.list_all_tables():
-            pdtest.assert_frame_equal(
-                original_tables[table], rel_data.get_table_data(table)
-            )
 
 
 def test_prepare_training_data_translates_alphanumeric_keys_and_adds_min_max_records(

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -32,6 +32,20 @@ def test_prepare_training_data_returns_multigenerational_data_without_keys_or_hi
     }
 
 
+def test_preparing_training_data_does_not_mutate_source_data(pets, art):
+    for rel_data in [pets, art]:
+        original_tables = {
+            table: rel_data.get_table_data(table).copy()
+            for table in rel_data.list_all_tables()
+        }
+
+        strategy = AncestralStrategy()
+        strategy.prepare_training_data(rel_data)
+
+        for table in rel_data.list_all_tables():
+            pdtest.assert_frame_equal(original_tables[table], rel_data.get_table_data(table))
+
+
 def test_prepare_training_data_translates_alphanumeric_keys_and_adds_min_max_records(art):
     strategy = AncestralStrategy()
 

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -42,10 +42,14 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
         strategy.prepare_training_data(rel_data)
 
         for table in rel_data.list_all_tables():
-            pdtest.assert_frame_equal(original_tables[table], rel_data.get_table_data(table))
+            pdtest.assert_frame_equal(
+                original_tables[table], rel_data.get_table_data(table)
+            )
 
 
-def test_prepare_training_data_translates_alphanumeric_keys_and_adds_min_max_records(art):
+def test_prepare_training_data_translates_alphanumeric_keys_and_adds_min_max_records(
+    art,
+):
     strategy = AncestralStrategy()
     training_data = strategy.prepare_training_data(art)
 

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -22,6 +22,20 @@ def test_prepare_training_data_removes_primary_and_foreign_keys(pets):
     assert set(training_data["pets"].columns) == {"name", "age"}
 
 
+def test_preparing_training_data_does_not_mutate_source_data(pets, art):
+    for rel_data in [pets, art]:
+        original_tables = {
+            table: rel_data.get_table_data(table).copy()
+            for table in rel_data.list_all_tables()
+        }
+
+        strategy = IndependentStrategy()
+        strategy.prepare_training_data(rel_data)
+
+        for table in rel_data.list_all_tables():
+            pdtest.assert_frame_equal(original_tables[table], rel_data.get_table_data(table))
+
+
 def test_retraining_a_set_of_tables_only_retrains_those_tables(ecom):
     strategy = IndependentStrategy()
     assert set(strategy.tables_to_retrain(["users"], ecom)) == {"users"}

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -33,7 +33,9 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
         strategy.prepare_training_data(rel_data)
 
         for table in rel_data.list_all_tables():
-            pdtest.assert_frame_equal(original_tables[table], rel_data.get_table_data(table))
+            pdtest.assert_frame_equal(
+                original_tables[table], rel_data.get_table_data(table)
+            )
 
 
 def test_retraining_a_set_of_tables_only_retrains_those_tables(ecom):

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -14,14 +14,6 @@ from gretel_trainer.relational.core import TableEvaluation
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
 
 
-def test_prepare_training_data_removes_primary_and_foreign_keys(pets):
-    strategy = IndependentStrategy()
-
-    training_data = strategy.prepare_training_data(pets)
-
-    assert set(training_data["pets"].columns) == {"name", "age"}
-
-
 def test_preparing_training_data_does_not_mutate_source_data(pets, art):
     for rel_data in [pets, art]:
         original_tables = {
@@ -36,6 +28,14 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
             pdtest.assert_frame_equal(
                 original_tables[table], rel_data.get_table_data(table)
             )
+
+
+def test_prepare_training_data_removes_primary_and_foreign_keys(pets):
+    strategy = IndependentStrategy()
+
+    training_data = strategy.prepare_training_data(pets)
+
+    assert set(training_data["pets"].columns) == {"name", "age"}
 
 
 def test_retraining_a_set_of_tables_only_retrains_those_tables(ecom):


### PR DESCRIPTION
Updates to how AncestralStrategy prepares training data:
- translates all keys (numeric or alphanumeric) to contiguous integers
- drops highly-NaN ancestral fields from training data (this is in addition to dropping highly-unique categorical ancestral fields, which we were already doing)
- adds new artificial records with min/max PK/FK values (instead of modifying existing records)