### PR TITLE
MultiRun

### DIFF
--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -53,4 +53,4 @@ def create_report(multitable: MultiTable) -> None:
     logger.info(
         "The `create_report` function is deprecated and will be removed in a future release. Instead call the `MultiTable#create_relational_report` instance method."
     )
-    multitable.create_relational_report()
+    multitable.create_relational_report(multitable._working_dir)

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -53,4 +53,4 @@ def create_report(multitable: MultiTable) -> None:
     logger.info(
         "The `create_report` function is deprecated and will be removed in a future release. Instead call the `MultiTable#create_relational_report` instance method."
     )
-    multitable.create_relational_report(multitable._working_dir)
+    multitable.create_relational_report()

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -1,4 +1,9 @@
+import os
+import shutil
+import tarfile
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from gretel_client.projects import Project
@@ -32,3 +37,23 @@ class ArtifactCollection:
         if existing is not None:
             project.delete_artifact(existing)
         return latest
+
+
+def add_to_tar(targz: Path, src: Path, arcname: str) -> None:
+    if targz.exists():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            backup = tmpdir / "backup.tar.gz"
+            shutil.copy(targz, backup)
+
+            with tarfile.open(targz, "w:gz") as w, tarfile.open(backup, "r:gz") as r:
+                w.add(src, arcname=arcname)
+
+                r.extractall(tmpdir)
+                for member in r.getnames():
+                    if os.path.isfile(tmpdir / member):
+                        w.add(tmpdir / member, arcname=member)
+    else:
+        with tarfile.open(targz, "w:gz") as tar:
+            tar.add(src, arcname=arcname)

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -65,15 +65,13 @@ class BackupTrain:
 
 
 @dataclass
-class BackupGenerateTable:
-    record_handler_id: str
-
-
-@dataclass
 class BackupGenerate:
+    identifier: str
     preserved: List[str]
     record_size_ratio: float
-    tables: Dict[str, BackupGenerateTable]
+    record_handler_ids: Dict[str, str]
+    lost_contact: List[str]
+    missing_model: List[str]
 
 
 @dataclass
@@ -133,13 +131,6 @@ class Backup:
 
         generate = b.get("generate")
         if generate is not None:
-            bg = BackupGenerate(
-                preserved=generate["preserved"],
-                record_size_ratio=generate["record_size_ratio"],
-                tables={
-                    k: BackupGenerateTable(**v) for k, v in generate["tables"].items()
-                },
-            )
-            backup.generate = bg
+            backup.generate = BackupGenerate(**generate)
 
         return backup

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -49,19 +49,16 @@ class BackupRelationalData:
 
 
 @dataclass
-class BackupTrainTable:
-    model_id: str
-    training_columns: List[str]
-
-
-@dataclass
-class BackupTransforms:
+class BackupTransformsTrain:
     model_ids: Dict[str, str]
+    lost_contact: List[str]
 
 
 @dataclass
-class BackupTrain:
-    tables: Dict[str, BackupTrainTable]
+class BackupSyntheticsTrain:
+    model_ids: Dict[str, str]
+    lost_contact: List[str]
+    training_columns: Dict[str, List[str]]
 
 
 @dataclass
@@ -83,8 +80,8 @@ class Backup:
     refresh_interval: int
     artifact_collection: ArtifactCollection
     relational_data: BackupRelationalData
-    transforms: Optional[BackupTransforms] = None
-    train: Optional[BackupTrain] = None
+    transforms_train: Optional[BackupTransformsTrain] = None
+    synthetics_train: Optional[BackupSyntheticsTrain] = None
     generate: Optional[BackupGenerate] = None
 
     @property
@@ -118,16 +115,13 @@ class Backup:
             relational_data=brd,
         )
 
-        transforms = b.get("transforms")
-        if transforms is not None:
-            backup.transforms = BackupTransforms(**transforms)
+        transforms_train = b.get("transforms_train")
+        if transforms_train is not None:
+            backup.transforms_train = BackupTransformsTrain(**transforms_train)
 
-        train = b.get("train")
-        if train is not None:
-            bt = BackupTrain(
-                tables={k: BackupTrainTable(**v) for k, v in train["tables"].items()}
-            )
-            backup.train = bt
+        synthetics_train = b.get("synthetics_train")
+        if synthetics_train is not None:
+            backup.synthetics_train = BackupSyntheticsTrain(**synthetics_train)
 
         generate = b.get("generate")
         if generate is not None:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -300,10 +300,16 @@ class MultiTable:
                     self.synthetic_output_tables[table] = pd.read_csv(
                         self._working_dir / latest_run_id / f"synth_{table}.csv"
                     )
+                except FileNotFoundError:
+                    logger.info(
+                        f"Could not find synthetic CSV for table `{table}` in run outputs."
+                    )
+
+                try:
                     self._attach_existing_reports(latest_run_id, table)
                 except FileNotFoundError:
                     logger.info(
-                        f"Could not find data for table `{table}` in run outputs."
+                        f"Could not find report data for table `{table}` in run outputs."
                     )
             return None
         else:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -284,7 +284,7 @@ class MultiTable:
         if backup_generate is None:
             if any_outputs:
                 # We shouldn't ever encounter this branch in the wild, but we define some guidance to log just in case.
-                msg = "Backup included synthetics outputs archive but no detailed run history. Review previous runs' outputs (see CSVs and reports in the local directory), or start a new one by calling `generate`."
+                msg = "Backup included synthetics outputs archive but no latest run detail. Review previous runs' outputs (see CSVs and reports in the local directory), or start a new one by calling `generate`."
             else:
                 # This branch is definitely possible / more likely.
                 msg = "No generation jobs had been started in previous instance. From here, your next step is to call `generate`."
@@ -307,9 +307,6 @@ class MultiTable:
         latest_run_id = self._synthetics_run.identifier
         if latest_run_id in os.listdir(self._working_dir):
             # Latest backup was taken at a stable point (nothing actively in progress).
-            logger.info(
-                f"Found artifacts for latest run ID `{latest_run_id}` in outputs archive."
-            )
             for table in self.relational_data.list_all_tables():
                 try:
                     self.synthetic_output_tables[table] = pd.read_csv(
@@ -326,6 +323,9 @@ class MultiTable:
                     logger.info(
                         f"Could not find report data for table `{table}` in run outputs."
                     )
+            logger.info(
+                f"All tasks for generation run `{latest_run_id}` finished prior to backup. From here, you can access your synthetic data as Pandas DataFrames via `synthetic_output_tables`, or review them in CSV format along with the relational report in the local working directory."
+            )
             return None
         else:
             # Latest run was still in progress. Download any seeds we may have previously created.

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -935,7 +935,8 @@ class MultiTable:
         self.synthetic_output_tables = output_tables
         self._backup()
 
-    def create_relational_report(self, target_dir: Path) -> None:
+    def create_relational_report(self, target_dir: Optional[Path] = None) -> None:
+        target_dir = target_dir or self._working_dir
         presenter = ReportPresenter(
             rel_data=self.relational_data,
             evaluations=self.evaluations,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -509,6 +509,7 @@ class MultiTable:
         Otherwise runs source data through all existing transforms models.
         """
         identifier = identifier or f"transforms_{_timestamp()}"
+        logger.info(f"Starting transforms run `{identifier}`")
         run_dir = _mkdir(str(self._working_dir / identifier))
         transforms_run_paths = {}
         if data is not None:
@@ -771,6 +772,7 @@ class MultiTable:
                 raise MultiTableException(
                     "Cannot resume a synthetics generation run without existing run information."
                 )
+            logger.info(f"Resuming synthetics run `{self._synthetics_run.identifier}`")
         else:
             preserve_tables = preserve_tables or []
             self._strategy.validate_preserved_tables(
@@ -788,6 +790,7 @@ class MultiTable:
                 record_handlers={},
                 lost_contact=[],
             )
+            logger.info(f"Starting synthetics run `{self._synthetics_run.identifier}`")
 
         run_dir = _mkdir(str(self._working_dir / self._synthetics_run.identifier))
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -884,6 +884,10 @@ class MultiTable:
 
         for table, data in output_tables.items():
             if data is not None:
+                data.to_csv(run_dir / f"synth_{table}.csv", index=False)
+
+        for table, data in output_tables.items():
+            if data is not None:
                 # Get "opposite" evaluation metrics
                 self._strategy.update_evaluation_via_evaluate(
                     evaluation=self.evaluations[table],
@@ -898,7 +902,10 @@ class MultiTable:
                     for ext in ["html", "json"]:
                         filename = f"synthetics_{eval_type}_evaluation_{table}.{ext}"
                         with suppress(FileNotFoundError):
-                            shutil.copyfile(filename, f"{run_dir}/{filename}")
+                            shutil.copyfile(
+                                src=self._working_dir / filename,
+                                dst=run_dir / filename,
+                            )
 
         logger.info("Creating relational report")
         self.create_relational_report(run_dir)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -24,7 +24,7 @@ from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.records import RecordHandler
 
-from gretel_trainer.relational.artifacts import ArtifactCollection
+from gretel_trainer.relational.artifacts import ArtifactCollection, add_to_tar
 from gretel_trainer.relational.backup import (
     Backup,
     BackupForeignKey,
@@ -594,8 +594,7 @@ class MultiTable:
             df.to_csv(out_path, index=False)
 
         archive_path = self._working_dir / "transforms_outputs.tar.gz"
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(run_dir, arcname=identifier)
+        add_to_tar(archive_path, run_dir, identifier)
 
         self._artifact_collection.upload_transforms_outputs_archive(
             self._project, str(archive_path)
@@ -911,8 +910,7 @@ class MultiTable:
         self.create_relational_report(run_dir)
 
         archive_path = self._working_dir / f"synthetics_outputs.tar.gz"
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(run_dir, arcname=identifier)
+        add_to_tar(archive_path, run_dir, self._synthetics_run.identifier)
 
         self._artifact_collection.upload_synthetics_outputs_archive(
             self._project, str(archive_path)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -452,7 +452,7 @@ class MultiTable:
         for table, config in configs.items():
             # Ensure consistent, friendly model name in Console
             named_config = read_model_config(config)
-            named_config["name"] = f"{table}-transforms"
+            named_config["name"] = _model_name("transforms", table)
 
             # Ensure consistent, friendly data source names in Console
             table_data = self.relational_data.get_table_data(table)
@@ -638,7 +638,7 @@ class MultiTable:
 
     def _table_model_config(self, table_name: str) -> Dict:
         config_dict = read_model_config(self._model_config)
-        config_dict["name"] = table_name
+        config_dict["name"] = _model_name("synthetics", table_name)
         return config_dict
 
     def _train_synthetics_models(self, training_data: Dict[str, Path]) -> None:
@@ -1080,6 +1080,11 @@ def _upload_gretel_backup(project: Project, path: str) -> None:
         key = artifact["key"]
         if key != latest and key.endswith("__gretel_backup.json"):
             project.delete_artifact(key)
+
+
+def _model_name(workflow: str, table: str) -> str:
+    ok_table_name = table.replace("--", "__")
+    return f"{workflow}-{ok_table_name}"
 
 
 def _timestamp() -> str:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -30,7 +30,6 @@ from gretel_trainer.relational.backup import (
     BackupForeignKey,
     BackupGenerate,
     BackupRelationalData,
-    BackupRelationalDataTable,
     BackupSyntheticsTrain,
     BackupTransformsTrain,
 )

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -758,7 +758,7 @@ class MultiTable:
         Args:
             record_size_ratio (float, optional): Ratio to upsample real world data size with. Defaults to 1.
             preserve_tables (list[str], optional): List of tables to skip sampling and leave (mostly) identical to source.
-            identifier (str, optional): Unique string identifying a specific call to this method. Defaults to current timestamp.
+            identifier (str, optional): Unique string identifying a specific call to this method. Defaults to "synthetics_" + current timestamp.
             resume (bool, optional): Set to True when restoring from a backup to complete a previous, interrupted run.
 
         Returns:
@@ -789,7 +789,7 @@ class MultiTable:
                 preserve_tables, self.relational_data
             )
 
-            identifier = identifier or _timestamp()
+            identifier = identifier or f"synthetics_{_timestamp()}"
             missing_model = self._list_tables_with_missing_models()
 
             self._synthetics_run = SyntheticsRun(

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -212,14 +212,20 @@ class MultiTable:
 
         logger.info("Restoring synthetics models")
 
-        self._synthetics_train.training_columns = backup_synthetics_train.training_columns
+        self._synthetics_train.training_columns = (
+            backup_synthetics_train.training_columns
+        )
         self._synthetics_train.lost_contact = backup_synthetics_train.lost_contact
         self._synthetics_train.models = {
             table: self._project.get_model(model_id)
             for table, model_id in backup_synthetics_train.model_ids.items()
         }
 
-        still_in_progress = [table for table, model in self._synthetics_train.models.items() if model.status in ACTIVE_STATES]
+        still_in_progress = [
+            table
+            for table, model in self._synthetics_train.models.items()
+            if model.status in ACTIVE_STATES
+        ]
         if len(still_in_progress) > 0:
             logger.warning(
                 f"Training still in progress for tables `{still_in_progress}`. From here, your next step is to wait for training to finish, and re-attempt restoring from backup once all models have completed training. You can view training progress in the Console in the `{self._project.display_name} ({self._project.name})` project."
@@ -228,17 +234,27 @@ class MultiTable:
                 "Cannot restore while model training is actively in progress."
             )
 
-        training_succeeded = [table for table, model in self._synthetics_train.models.items() if model.status == Status.COMPLETED]
+        training_succeeded = [
+            table
+            for table, model in self._synthetics_train.models.items()
+            if model.status == Status.COMPLETED
+        ]
         for table in training_succeeded:
             model = self._synthetics_train.models[table]
             download_file_artifact(
-                self._project, model.data_source, self._working_dir / f"synthetics_train_{table}.csv",
+                self._project,
+                model.data_source,
+                self._working_dir / f"synthetics_train_{table}.csv",
             )
             self._strategy.update_evaluation_from_model(
                 table, self.evaluations, model, self._working_dir
             )
 
-        training_failed = [table for table, model in self._synthetics_train.models.items() if model.status in END_STATES and table not in training_succeeded]
+        training_failed = [
+            table
+            for table, model in self._synthetics_train.models.items()
+            if model.status in END_STATES and table not in training_succeeded
+        ]
         if len(training_failed) > 0:
             logger.info(
                 f"Training failed for tables: {training_failed}. From here, your next step is to try retraining them with modified data by calling `retrain_tables`."

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -140,7 +140,7 @@ class AncestralStrategy:
         rel_data: RelationalData,
         record_size_ratio: float,
         output_tables: Dict[str, pd.DataFrame],
-        working_dir: Path,
+        target_dir: Path,
         training_columns: List[str],
     ) -> Dict[str, Any]:
         """
@@ -159,7 +159,7 @@ class AncestralStrategy:
             seed_df = self._build_seed_data_for_table(
                 table, output_tables, rel_data, synth_size, training_columns
             )
-            seed_path = working_dir / f"synthetics_seed_{table}.csv"
+            seed_path = target_dir / f"synthetics_seed_{table}.csv"
             seed_df.to_csv(seed_path, index=False)
             return {"data_source": str(seed_path)}
 

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -290,7 +290,7 @@ class AncestralStrategy:
         table: str,
         rel_data: RelationalData,
         synthetic_tables: Dict[str, pd.DataFrame],
-        working_dir: Path,
+        target_dir: Path,
     ) -> None:
         source_data = rel_data.get_table_data(table)
         synth_data = synthetic_tables[table]
@@ -299,7 +299,7 @@ class AncestralStrategy:
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )
-        out_filepath = working_dir / f"synthetics_individual_evaluation_{table}"
+        out_filepath = target_dir / f"synthetics_individual_evaluation_{table}"
         common.write_report(report, out_filepath)
 
         evaluation.individual_sqs = report.peek().get("score")

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -101,7 +101,7 @@ class IndependentStrategy:
         rel_data: RelationalData,
         record_size_ratio: float,
         output_tables: Dict[str, pd.DataFrame],
-        working_dir: Path,
+        target_dir: Path,
         training_columns: List[str],
     ) -> Dict[str, Any]:
         """

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -158,7 +158,7 @@ class IndependentStrategy:
         table: str,
         rel_data: RelationalData,
         synthetic_tables: Dict[str, pd.DataFrame],
-        working_dir: Path,
+        target_dir: Path,
     ) -> None:
         source_data = ancestry.get_table_data_with_ancestors(rel_data, table)
         synth_data = ancestry.get_table_data_with_ancestors(
@@ -169,7 +169,7 @@ class IndependentStrategy:
         report = common.get_quality_report(
             source_data=source_data, synth_data=synth_data
         )
-        out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table}"
+        out_filepath = target_dir / f"synthetics_cross_table_evaluation_{table}"
         common.write_report(report, out_filepath)
 
         evaluation.cross_table_sqs = report.peek().get("score")

--- a/tests/relational/test_artifacts.py
+++ b/tests/relational/test_artifacts.py
@@ -1,0 +1,24 @@
+import tarfile
+import tempfile
+from pathlib import Path
+
+from gretel_trainer.relational.artifacts import add_to_tar
+
+
+def test_makes_new_archive():
+    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
+        archive_path = Path(tmpdir) / "archive.tar.gz"
+        add_to_tar(archive_path, Path(tf1.name), "tf1")
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            assert len(tar.getnames()) == 1
+
+
+def test_appends_to_existing_archive():
+    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
+        archive_path = Path(tmpdir) / "archive.tar.gz"
+        add_to_tar(archive_path, Path(tf1.name), "tf1")
+        add_to_tar(archive_path, Path(tf2.name), "tf2")
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            assert len(tar.getnames()) == 2

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -7,9 +7,8 @@ from gretel_trainer.relational.backup import (
     BackupGenerate,
     BackupRelationalData,
     BackupRelationalDataTable,
-    BackupTrain,
-    BackupTrainTable,
-    BackupTransforms,
+    BackupSyntheticsTrain,
+    BackupTransformsTrain,
 )
 
 
@@ -45,23 +44,23 @@ def test_backup():
             )
         ],
     )
-    backup_transforms = BackupTransforms(
+    backup_transforms_train = BackupTransformsTrain(
         model_ids={
             "customer": "222333444",
             "address": "888777666",
-        }
+        },
+        lost_contact=[],
     )
-    backup_train = BackupTrain(
-        tables={
-            "customer": BackupTrainTable(
-                model_id="1234567890",
-                training_columns=["id", "first", "last"],
-            ),
-            "address": BackupTrainTable(
-                model_id="0987654321",
-                training_columns=["customer_id", "street", "city"],
-            ),
-        }
+    backup_synthetics_train = BackupSyntheticsTrain(
+        model_ids={
+            "customer": "1234567890",
+            "address": "0987654321",
+        },
+        training_columns={
+            "customer": ["id", "first", "last"],
+            "address": ["customer_id", "street", "city"],
+        },
+        lost_contact=[],
     )
     backup_generate = BackupGenerate(
         identifier="run-id",
@@ -86,8 +85,8 @@ def test_backup():
         refresh_interval=120,
         artifact_collection=artifact_collection,
         relational_data=backup_relational,
-        transforms=backup_transforms,
-        train=backup_train,
+        transforms_train=backup_transforms_train,
+        synthetics_train=backup_synthetics_train,
         generate=backup_generate,
     )
 

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -5,7 +5,6 @@ from gretel_trainer.relational.backup import (
     Backup,
     BackupForeignKey,
     BackupGenerate,
-    BackupGenerateTable,
     BackupRelationalData,
     BackupRelationalDataTable,
     BackupTrain,
@@ -65,15 +64,14 @@ def test_backup():
         }
     )
     backup_generate = BackupGenerate(
+        identifier="run-id",
         preserved=[],
         record_size_ratio=1.0,
-        tables={
-            "customer": BackupGenerateTable(
-                record_handler_id="555444666",
-            ),
-            "address": BackupGenerateTable(
-                record_handler_id="333111222",
-            ),
+        lost_contact=[],
+        missing_model=[],
+        record_handler_ids={
+            "customer": "555444666",
+            "address": "333111222",
         },
     )
     artifact_collection = ArtifactCollection(

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -69,9 +69,7 @@ def make_backup(
             model_ids={
                 table: mock.model_id for table, mock in synthetics_models.items()
             },
-            training_columns={
-                table: ["col1", "col2"] for table in synthetics_models
-            },
+            training_columns={table: ["col1", "col2"] for table in synthetics_models},
             lost_contact=[],
         )
     if len(synthetics_record_handlers) > 0:

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -490,6 +490,7 @@ def test_restore_generate_completed(project, pets):
             pets,
             working_dir,
             synthetics_models=synthetics_models,
+            synthetics_record_handlers=synthetics_record_handlers,
             output_archive_present=True,
         )
 
@@ -514,12 +515,12 @@ def test_restore_generate_completed(project, pets):
         assert os.path.exists(
             working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.html"
         )
-        assert mt._synthetics_run is None
-        assert len(mt.synthetic_output_tables) == 0
-        assert mt.evaluations["humans"].individual_sqs == 94
-        assert mt.evaluations["humans"].cross_table_sqs is None
-        assert mt.evaluations["pets"].individual_sqs == 94
-        assert mt.evaluations["pets"].cross_table_sqs is None
+        assert mt._synthetics_run is not None
+        assert len(mt.synthetic_output_tables) == 2
+        assert mt.evaluations["humans"].individual_sqs == 90
+        assert mt.evaluations["humans"].cross_table_sqs is 91
+        assert mt.evaluations["pets"].individual_sqs == 90
+        assert mt.evaluations["pets"].cross_table_sqs == 91
 
 
 def test_restore_generate_in_progress(project, pets):

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -12,7 +12,7 @@ import pytest
 import gretel_trainer.relational.backup as b
 from gretel_trainer.relational.artifacts import ArtifactCollection
 from gretel_trainer.relational.core import MultiTableException, RelationalData
-from gretel_trainer.relational.multi_table import MultiTable, TrainStatus
+from gretel_trainer.relational.multi_table import MultiTable, SyntheticsRun, TrainStatus
 
 DEBUG_SUMMARY_CONTENT = {"debug": "summary"}
 
@@ -75,10 +75,13 @@ def make_backup(
         )
     if len(synthetics_record_handlers) > 0:
         backup.generate = b.BackupGenerate(
+            identifier="run-id",
             preserved=[],
             record_size_ratio=1.0,
-            tables={
-                table: b.BackupGenerateTable(record_handler_id=mock.record_handler_id)
+            lost_contact=[],
+            missing_model=[],
+            record_handler_ids={
+                table: mock.record_id
                 for table, mock in synthetics_record_handlers.items()
             },
         )
@@ -172,7 +175,7 @@ def make_mock_model(
 def make_mock_record_handler(name: str, status: str) -> Mock:
     record_handler = Mock()
     record_handler.status = status
-    record_handler.record_handler_id = name
+    record_handler.record_id = name
     record_handler.data_source = None
     return record_handler
 
@@ -208,13 +211,13 @@ def create_standin_project_artifacts(
         for table in rel_data.list_all_tables():
             table_path = setup_path / f"synth_{table}.csv"
             rel_data.get_table_data(table).to_csv(table_path, index=False)
-            tar.add(table_path, arcname=f"synth_{table}.csv")
+            tar.add(table_path, arcname=f"run-id/synth_{table}.csv")
             for kind, score in [("individual", 90), ("cross_table", 91)]:
                 html_filename = f"synthetics_{kind}_evaluation_{table}.html"
                 html_path = setup_path / html_filename
                 with open(html_path, "w") as f:
                     f.write("<html></html>")
-                tar.add(html_path, arcname=html_filename)
+                tar.add(html_path, arcname=f"run-id/{html_filename}")
                 json_filename = f"synthetics_{kind}_evaluation_{table}.json"
                 json_path = setup_path / json_filename
                 with open(json_path, "w") as f:
@@ -229,7 +232,7 @@ def create_standin_project_artifacts(
                         },
                         f,
                     )
-                tar.add(json_path, arcname=json_filename)
+                tar.add(json_path, arcname=f"run-id/{json_filename}")
 
 
 # For non-archive files, we patch Project#get_artifact_link to return paths to files
@@ -487,38 +490,36 @@ def test_restore_generate_completed(project, pets):
             pets,
             working_dir,
             synthetics_models=synthetics_models,
-            synthetics_record_handlers=synthetics_record_handlers,
             output_archive_present=True,
         )
 
         mt = MultiTable.restore(backup_file)
 
         # Backup + Debug summary + Source archive + (2) Source CSVs
-        # + (2) Train CSVs + (8) Reports + Outputs archive + 2 Synth CSVs
-        assert len(os.listdir(working_dir)) == 18
+        # + (2) Train CSVs + (4) Reports + Outputs archive + Previous run subdirectory
+        assert len(os.listdir(working_dir)) == 13
 
         # Generate state is restored
-        assert os.path.exists(working_dir / "synth_humans.csv")
+        assert os.path.exists(working_dir / "run-id" / "synth_humans.csv")
         assert os.path.exists(
-            working_dir / "synthetics_cross_table_evaluation_humans.json"
+            working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.json"
         )
         assert os.path.exists(
-            working_dir / "synthetics_cross_table_evaluation_humans.html"
+            working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.html"
         )
-        assert os.path.exists(working_dir / "synth_pets.csv")
+        assert os.path.exists(working_dir / "run-id" / "synth_pets.csv")
         assert os.path.exists(
-            working_dir / "synthetics_cross_table_evaluation_pets.json"
+            working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.json"
         )
         assert os.path.exists(
-            working_dir / "synthetics_cross_table_evaluation_pets.html"
+            working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.html"
         )
-        assert set(mt.synthetics_generate_statuses.values()) == {TrainStatus.Completed}
-        assert len(mt._synthetics_record_handlers) == 2
-        assert len(mt.synthetic_output_tables) == 2
-        assert mt.evaluations["humans"].individual_sqs == 90
-        assert mt.evaluations["humans"].cross_table_sqs == 91
-        assert mt.evaluations["pets"].individual_sqs == 90
-        assert mt.evaluations["pets"].cross_table_sqs == 91
+        assert mt._synthetics_run is None
+        assert len(mt.synthetic_output_tables) == 0
+        assert mt.evaluations["humans"].individual_sqs == 94
+        assert mt.evaluations["humans"].cross_table_sqs is None
+        assert mt.evaluations["pets"].individual_sqs == 94
+        assert mt.evaluations["pets"].cross_table_sqs is None
 
 
 def test_restore_generate_in_progress(project, pets):
@@ -569,8 +570,14 @@ def test_restore_generate_in_progress(project, pets):
         assert len(os.listdir(working_dir)) == 11
 
         # Generate state is partially restored
-        assert set(mt.synthetics_generate_statuses.values()) == {TrainStatus.Completed}
-        assert len(mt._synthetics_record_handlers) == 2
+        assert mt._synthetics_run == SyntheticsRun(
+            identifier="run-id",
+            preserved=[],
+            record_size_ratio=1.0,
+            lost_contact=[],
+            missing_model=[],
+            record_handlers=synthetics_record_handlers,
+        )
         assert len(mt.synthetic_output_tables) == 0
         assert mt.evaluations["humans"].individual_sqs == 94
         assert mt.evaluations["humans"].cross_table_sqs is None


### PR DESCRIPTION
Each call to `run_transforms` or `generate` is assigned an identifier (optionally supplied by user, or default to `{workflow}_{timestamp}`). All outputs (transformed tables; synthetic tables + reports) from these calls are exported to a subdirectory in the local working directory (e.g. `mike-79sa1/synthetics_20230223010203/`). These subdirectories are added to the outputs archive, which is continually re-upload to the project after each run.

Also tweaks how we name models, mainly to ensure model regex rules are met:
- Always include the workflow in the model name (previously would include "transforms" in name but not "synthetics")
- Use workflow as prefix instead of suffix
- Replace any double-hyphens with double-underscores (unlikely, but just in case)