### PR TITLE
Sad path improvements

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -134,6 +134,19 @@ class RelationalData:
     def get_parents(self, table: str) -> List[str]:
         return list(self.graph.successors(table))
 
+    def get_ancestors(self, table: str) -> List[str]:
+        def _add_parents(ancestors, table):
+            parents = self.get_parents(table)
+            if len(parents) > 0:
+                ancestors.update(parents)
+                for parent in parents:
+                    _add_parents(ancestors, parent)
+
+        ancestors = set()
+        _add_parents(ancestors, table)
+
+        return list(ancestors)
+
     def get_descendants(self, table: str) -> List[str]:
         def _add_children(descendants, table):
             children = list(self.graph.predecessors(table))

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -838,11 +838,13 @@ class MultiTable:
                     self._log_lost_contact(table_name)
                     self._synthetics_run.lost_contact.append(table_name)
                     output_tables[table_name] = None
-                    for descendant in self.relational_data.get_descendants(table_name):
+                    for other_table in self._strategy.tables_to_skip_when_failed(
+                        table_name, self.relational_data
+                    ):
                         logger.info(
-                            f"Skipping synthetic data generation for `{descendant}` because it depends on `{table_name}`"
+                            f"Skipping synthetic data generation for `{other_table}` because it depends on `{table_name}`"
                         )
-                        output_tables[descendant] = None
+                        output_tables[other_table] = None
                     self._backup()
                     continue
 
@@ -860,11 +862,13 @@ class MultiTable:
                     # already checked explicitly for completed; all other end states are effectively failures
                     self._log_failed(table_name, "synthetic data generation")
                     output_tables[table_name] = None
-                    for descendant in self.relational_data.get_descendants(table_name):
+                    for other_table in self._strategy.tables_to_skip_when_failed(
+                        table_name, self.relational_data
+                    ):
                         logger.info(
-                            f"Skipping synthetic data generation for `{descendant}` because it depends on `{table_name}`"
+                            f"Skipping synthetic data generation for `{other_table}` because it depends on `{table_name}`"
                         )
-                        output_tables[descendant] = None
+                        output_tables[other_table] = None
                 else:
                     self._log_in_progress(
                         table_name, status, "synthetic data generation"

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -484,16 +484,15 @@ class MultiTable:
                 if table_name in (completed + failed):
                     continue
 
+                model = self._transforms_train.models[table_name]
+                status = cautiously_refresh_status(model, table_name, refresh_attempts)
+
                 # If we consistently failed to refresh the job status, fail the table
                 if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     self._transforms_train.lost_contact.append(table_name)
                     failed.append(table_name)
                     continue
-
-                model = self._transforms_train.models[table_name]
-
-                status = cautiously_refresh_status(model, table_name, refresh_attempts)
 
                 if status == Status.COMPLETED:
                     self._log_success(table_name, "model training")
@@ -572,15 +571,15 @@ class MultiTable:
                 if table_name in output_tables:
                     continue
 
+                status = cautiously_refresh_status(
+                    record_handler, table_name, refresh_attempts
+                )
+
                 # If we consistently failed to refresh the job via API, fail the table
                 if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     output_tables[table_name] = None
                     continue
-
-                status = cautiously_refresh_status(
-                    record_handler, table_name, refresh_attempts
-                )
 
                 if status == Status.COMPLETED:
                     self._log_success(table_name, "transforms run")
@@ -672,16 +671,15 @@ class MultiTable:
                 if table_name in (completed + failed):
                     continue
 
+                model = self._synthetics_train.models[table_name]
+                status = cautiously_refresh_status(model, table_name, refresh_attempts)
+
                 # If we consistently failed to refresh the job status, fail the table
                 if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
                     self._synthetics_train.lost_contact.append(table_name)
                     failed.append(table_name)
                     continue
-
-                model = self._synthetics_train.models[table_name]
-
-                status = cautiously_refresh_status(model, table_name, refresh_attempts)
 
                 if status == Status.COMPLETED:
                     self._log_success(table_name, "model training")
@@ -831,6 +829,10 @@ class MultiTable:
                 if table_name in output_tables:
                     continue
 
+                status = cautiously_refresh_status(
+                    record_handler, table_name, refresh_attempts
+                )
+
                 # If we consistently failed to refresh the job via API, fail the table
                 if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                     self._log_lost_contact(table_name)
@@ -838,10 +840,6 @@ class MultiTable:
                     output_tables[table_name] = None
                     self._backup()
                     continue
-
-                status = cautiously_refresh_status(
-                    record_handler, table_name, refresh_attempts
-                )
 
                 if status == Status.COMPLETED:
                     self._log_success(table_name, "synthetic data generation")

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -838,6 +838,11 @@ class MultiTable:
                     self._log_lost_contact(table_name)
                     self._synthetics_run.lost_contact.append(table_name)
                     output_tables[table_name] = None
+                    for descendant in self.relational_data.get_descendants(table_name):
+                        logger.info(
+                            f"Skipping synthetic data generation for `{descendant}` because it depends on `{table_name}`"
+                        )
+                        output_tables[descendant] = None
                     self._backup()
                     continue
 

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -261,7 +261,6 @@ class AncestralStrategy:
         """
         Restores tables from multigenerational to original shape
         """
-        # TODO: do we need to do any additional PK/FK manipulation?
         return {
             table_name: ancestry.drop_ancestral_data(df)
             for table_name, df in output_tables.items()

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -229,6 +229,11 @@ class AncestralStrategy:
 
         return seed_df
 
+    def tables_to_skip_when_failed(
+        self, table: str, rel_data: RelationalData
+    ) -> List[str]:
+        return rel_data.get_descendants(table)
+
     def post_process_individual_synthetic_result(
         self,
         table_name: str,

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -108,7 +108,10 @@ def label_encode_keys(
         source_values.update(df[primary_key].to_list())
         for fk_ref in fk_references:
             fk_tbl, fk_col = fk_ref
-            source_values.update(tables[fk_tbl][fk_col].to_list())
+            fk_df = tables.get(fk_tbl)
+            if fk_df is None:
+                continue
+            source_values.update(fk_df[fk_col].to_list())
 
         # Fit a label encoder on all values
         le = preprocessing.LabelEncoder()
@@ -119,6 +122,9 @@ def label_encode_keys(
 
         for fk_ref in fk_references:
             fk_tbl, fk_col = fk_ref
-            tables[fk_tbl][fk_col] = le.transform(tables[fk_tbl][fk_col])
+            fk_df = tables.get(fk_tbl)
+            if fk_df is None:
+                continue
+            fk_df[fk_col] = le.transform(fk_df[fk_col])
 
     return tables

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -169,6 +169,17 @@ class IndependentStrategy:
         synthetic_tables: Dict[str, pd.DataFrame],
         target_dir: Path,
     ) -> None:
+        missing_ancestors = [
+            ancestor
+            for ancestor in rel_data.get_ancestors(table)
+            if ancestor not in synthetic_tables
+        ]
+        if len(missing_ancestors) > 0:
+            logger.info(
+                f"Cannot run cross_table evaluations for `{table}` because no synthetic data exists for ancestor tables {missing_ancestors}."
+            )
+            return None
+
         source_data = ancestry.get_table_data_with_ancestors(rel_data, table)
         synth_data = ancestry.get_table_data_with_ancestors(
             rel_data, table, synthetic_tables

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -16,6 +16,19 @@ def test_ecommerce_relational_data(ecom):
         "distribution_center",
     }
 
+    # get_parents goes back one generation,
+    # get_ancestors goes back all generations
+    assert set(ecom.get_parents("order_items")) == {
+        "users",
+        "inventory_items",
+    }
+    assert set(ecom.get_ancestors("order_items")) == {
+        "users",
+        "inventory_items",
+        "products",
+        "distribution_center",
+    }
+
 
 def test_mutagenesis_relational_data(mutagenesis):
     assert mutagenesis.get_parents("bond") == ["atom"]


### PR DESCRIPTION
Improvements to various sad-path scenarios, including:
- Flip order of job-status-check / max-refresh-attempts-bailout so that we don't needlessly wait `refresh_interval` seconds between final status check and bail
- Under ancestral strategy, skip generation jobs for descendant tables if we lose contact with a parent table
- Under independent strategy, skip cross_table evaluation if any parent tables failed and are unavailable
- Under independent strategy, keep synthetic data but set FK values to `None` when child generates successfully but parent fails
- Avoid potential KeyError in transforms