### PR TITLE
Show run ID instead of generated at time in relational report

### DIFF
--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -13,7 +13,7 @@ from gretel_trainer.relational.connectors import (
     snowflake_conn,
     sqlite_conn,
 )
-from gretel_trainer.relational.core import RelationalData
+from gretel_trainer.relational.core import MultiTableException, RelationalData
 from gretel_trainer.relational.multi_table import MultiTable
 
 # Optimize logging for multitable output
@@ -53,4 +53,13 @@ def create_report(multitable: MultiTable) -> None:
     logger.info(
         "The `create_report` function is deprecated and will be removed in a future release. Instead call the `MultiTable#create_relational_report` instance method."
     )
-    multitable.create_relational_report()
+    try:
+        run_id = multitable._synthetics_run.identifier  # type:ignore
+        target_dir = multitable._working_dir / run_id
+        multitable.create_relational_report(
+            run_identifier=run_id, target_dir=target_dir
+        )
+    except Exception as e:
+        raise MultiTableException(
+            "Could not create relational report via deprecated `create_report` function."
+        ) from e

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -941,7 +941,10 @@ class MultiTable:
                         )
 
         logger.info("Creating relational report")
-        self.create_relational_report(run_dir)
+        self.create_relational_report(
+            run_identifier=self._synthetics_run.identifier,
+            target_dir=run_dir,
+        )
 
         archive_path = self._working_dir / f"synthetics_outputs.tar.gz"
         add_to_tar(archive_path, run_dir, self._synthetics_run.identifier)
@@ -952,12 +955,12 @@ class MultiTable:
         self.synthetic_output_tables = output_tables
         self._backup()
 
-    def create_relational_report(self, target_dir: Optional[Path] = None) -> None:
-        target_dir = target_dir or self._working_dir
+    def create_relational_report(self, run_identifier: str, target_dir: Path) -> None:
         presenter = ReportPresenter(
             rel_data=self.relational_data,
             evaluations=self.evaluations,
             now=datetime.utcnow(),
+            run_identifier=run_identifier,
         )
         output_path = target_dir / "relational_report.html"
         with open(output_path, "w") as report:

--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -28,11 +28,8 @@ class ReportRenderer:
 class ReportPresenter:
     rel_data: RelationalData
     now: datetime.datetime
+    run_identifier: str
     evaluations: Dict[str, TableEvaluation]
-
-    @property
-    def generated_at(self) -> str:
-        return self.now.strftime("%m/%d/%Y, %H:%M")
 
     @property
     def copyright_year(self) -> str:

--- a/src/gretel_trainer/relational/report/report_template.html
+++ b/src/gretel_trainer/relational/report/report_template.html
@@ -16,7 +16,7 @@
 
         <div class="header">
           <h1>Gretel<br />Relational Synthetic Report</h1>
-          <span>Generated {{ presenter.generated_at }}</span>
+          <span>Generation run {{ presenter.run_identifier }}</span>
         </div>
 
     </div>


### PR DESCRIPTION
The relational report had been showing the generated-at time in UTC. Meanwhile, our default run identifier (when a user doesn't specify one) is the current time in the user's local timezone. (Note also, those two times won't match even regardless of timezone because one is set before generation begins, the other after it completes.)

This change removes the generated-at time from the relational report and replaces it with the run identifier (whether default local timestamp or user-specified string), making it easier for users to associate a report with a specific subdirectory of synthetic data (particularly when running generate multiple times).