### PR TITLE
Include both date of generation and run ID in report header

### DIFF
--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -30,7 +30,10 @@ class ReportPresenter:
     now: datetime.datetime
     run_identifier: str
     evaluations: Dict[str, TableEvaluation]
-
+    
+    @property
+    def generated_at(self) -> str:
+        return self.now.strftime("%Y-%m-%d")
     @property
     def copyright_year(self) -> str:
         return self.now.strftime("%Y")

--- a/src/gretel_trainer/relational/report/report_template.html
+++ b/src/gretel_trainer/relational/report/report_template.html
@@ -16,7 +16,8 @@
 
         <div class="header">
           <h1>Gretel<br />Relational Synthetic Report</h1>
-          <span>Generation run {{ presenter.run_identifier }}</span>
+          <span>Generated {{presenter.generated_at}}</span>
+          <span>Run ID: {{ presenter.run_identifier }}</span>
         </div>
 
     </div>


### PR DESCRIPTION
Relational report sub-header under title will now follow format

Generated {YYYY-mm-dd}
Run ID: {run_identifier}