### PR TITLE
Relational eviction

### DIFF
--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -13,6 +13,7 @@ from gretel_client.projects import Project
 class ArtifactCollection:
     gretel_debug_summary: Optional[str] = None
     source_archive: Optional[str] = None
+    synthetics_training_archive: Optional[str] = None
     synthetics_outputs_archive: Optional[str] = None
     transforms_outputs_archive: Optional[str] = None
 
@@ -23,6 +24,10 @@ class ArtifactCollection:
     def upload_source_archive(self, project: Project, path: str) -> None:
         existing = self.source_archive
         self.source_archive = self._upload_file(project, path, existing)
+
+    def upload_synthetics_training_archive(self, project: Project, path: str) -> None:
+        existing = self.synthetics_training_archive
+        self.synthetics_training_archive = self._upload_file(project, path, existing)
 
     def upload_synthetics_outputs_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_outputs_archive

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -949,6 +949,11 @@ class MultiTable:
             )
 
             for table_name in ready_tables:
+                # Any record handlers we create but defer submitting will continue to register as "ready" until they are submitted and become "in progress".
+                # This check prevents repeatedly incurring the cost of getting the generation job details while the job is deferred.
+                if self._synthetics_run.record_handlers.get(table_name) is not None:
+                    continue
+
                 present_working_tables = {
                     table: data
                     for table, data in working_tables.items()

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -244,6 +244,21 @@ class MultiTable:
             )
             return None
 
+        synthetics_training_archive_id = (
+            self._artifact_collection.synthetics_training_archive
+        )
+        if synthetics_training_archive_id is not None:
+            synthetics_training_archive_path = (
+                self._working_dir / "synthetics_training.tar.gz"
+            )
+            download_tar_artifact(
+                self._project,
+                synthetics_training_archive_id,
+                synthetics_training_archive_path,
+            )
+            with tarfile.open(synthetics_training_archive_path, "r:gz") as tar:
+                tar.extractall(path=self._working_dir)
+
         # Synthetics Generate
         ## First, download the outputs archive if present and extract the data.
         synthetics_outputs_archive_id = (
@@ -726,6 +741,13 @@ class MultiTable:
                     continue
 
             self._backup()
+
+        archive_path = self._working_dir / "synthetics_training.tar.gz"
+        for table_name, csv_path in training_data.items():
+            add_to_tar(archive_path, csv_path, csv_path.name)
+        self._artifact_collection.upload_synthetics_training_archive(
+            self._project, str(archive_path)
+        )
 
     def train(self) -> None:
         """Train synthetic data models on each table in the relational dataset"""

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -200,6 +200,21 @@ class MultiTable:
 
         logger.info("Restoring synthetics models")
 
+        synthetics_training_archive_id = (
+            self._artifact_collection.synthetics_training_archive
+        )
+        if synthetics_training_archive_id is not None:
+            synthetics_training_archive_path = (
+                self._working_dir / "synthetics_training.tar.gz"
+            )
+            download_tar_artifact(
+                self._project,
+                synthetics_training_archive_id,
+                synthetics_training_archive_path,
+            )
+            with tarfile.open(synthetics_training_archive_path, "r:gz") as tar:
+                tar.extractall(path=self._working_dir)
+
         self._synthetics_train.training_columns = (
             backup_synthetics_train.training_columns
         )
@@ -243,21 +258,6 @@ class MultiTable:
                 f"Training failed for tables: {training_failed}. From here, your next step is to try retraining them with modified data by calling `retrain_tables`."
             )
             return None
-
-        synthetics_training_archive_id = (
-            self._artifact_collection.synthetics_training_archive
-        )
-        if synthetics_training_archive_id is not None:
-            synthetics_training_archive_path = (
-                self._working_dir / "synthetics_training.tar.gz"
-            )
-            download_tar_artifact(
-                self._project,
-                synthetics_training_archive_id,
-                synthetics_training_archive_path,
-            )
-            with tarfile.open(synthetics_training_archive_path, "r:gz") as tar:
-                tar.extractall(path=self._working_dir)
 
         # Synthetics Generate
         ## First, download the outputs archive if present and extract the data.

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -316,13 +316,18 @@ class MultiTable:
             for table, rh in record_handlers.items():
                 data_source = rh.data_source
                 if data_source is not None:
-                    download_file_artifact(
-                        self._project,
-                        data_source,
-                        self._working_dir
-                        / backup_generate.identifier
-                        / f"synthetics_seed_{table}.csv",
-                    )
+                    try:
+                        download_file_artifact(
+                            self._project,
+                            data_source,
+                            self._working_dir
+                            / backup_generate.identifier
+                            / f"synthetics_seed_{table}.csv",
+                        )
+                    except:
+                        logger.warning(
+                            f"Could not download seed CSV data source for `{table}`. It may have already been deleted."
+                        )
             logger.info(
                 f"At time of last backup, generation run `{latest_run_id}` was still in progress. From here, you can attempt to resume that generate job via `generate(resume=True)`, or restart generation from scratch via a regular call to `generate`."
             )

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -1161,7 +1161,7 @@ def _table_trained_successfully(
 def _table_is_in_progress(run: SyntheticsRun, table: str) -> bool:
     in_progress = False
     record_handler = run.record_handlers.get(table)
-    if record_handler is not None:
+    if record_handler is not None and record_handler.record_id is not None:
         in_progress = record_handler.status in ACTIVE_STATES
     return in_progress
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -229,11 +229,6 @@ class MultiTable:
         ]
         for table in training_succeeded:
             model = self._synthetics_train.models[table]
-            download_file_artifact(
-                self._project,
-                model.data_source,
-                self._working_dir / f"synthetics_train_{table}.csv",
-            )
             self._strategy.update_evaluation_from_model(
                 table, self.evaluations, model, self._working_dir
             )

--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -30,10 +30,11 @@ class ReportPresenter:
     now: datetime.datetime
     run_identifier: str
     evaluations: Dict[str, TableEvaluation]
-    
+
     @property
     def generated_at(self) -> str:
         return self.now.strftime("%Y-%m-%d")
+
     @property
     def copyright_year(self) -> str:
         return self.now.strftime("%Y")

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -11,7 +11,7 @@ from gretel_client.projects.projects import Project
 
 logger = logging.getLogger(__name__)
 
-MAX_PROJECT_ARTIFACTS = 6
+MAX_PROJECT_ARTIFACTS = 50
 
 
 def room_in_project(project: Project) -> bool:

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -11,7 +11,7 @@ from gretel_client.projects.projects import Project
 
 logger = logging.getLogger(__name__)
 
-MAX_PROJECT_ARTIFACTS = 50
+MAX_PROJECT_ARTIFACTS = 6
 
 
 def room_in_project(project: Project) -> bool:

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -11,6 +11,17 @@ from gretel_client.projects.projects import Project
 
 logger = logging.getLogger(__name__)
 
+MAX_PROJECT_ARTIFACTS = 50
+
+
+def room_in_project(project: Project) -> bool:
+    return len(project.artifacts) < MAX_PROJECT_ARTIFACTS
+
+
+def delete_data_source(project: Project, job: Job) -> None:
+    if job.data_source is not None:
+        project.delete_artifact(job.data_source)
+
 
 def cautiously_refresh_status(
     job: Job, key: str, refresh_attempts: Dict[str, int]


### PR DESCRIPTION
Adds project artifact eviction logic to Relational Trainer to prevent running into project artifact limits during runtime. We delete any project artifacts associated directly with a singular job (e.g. a model training dataset, or a seed file for conditional generation) when the job completes (or fails/is marked lost), so when "nothing is going on" we should expect to see some/all of the following artifacts (in order of when they'd be added, typically):
```
_gretel_backup.json
_gretel_debug_summary.json
source_tables.tar.gz
transforms_outputs.tar.gz
synthetics_training.tar.gz
synthetics_outputs.tar.gz
```
When we queue up jobs, once we reach the artifact limit we hold off on deferring additional jobs until there is more room in the project. This runs on the same `refresh_interval` check as other status updates. For example, if we have 8 jobs deferred, and on the next status check 2 jobs complete, we'll submit 2 of the 8 jobs and hold onto 6 until more space is available.

We do not upload a `transforms_training.tar.gz` archive since that is essentially identical to / a subset of `source_tables.tar.gz`.

If a notebook is interrupted during an Ancestral generation run and then restored (whether in progress or complete), it is possible/likely that some tables' seed files will have been already deleted, but they will not have been added to the archive because that happens at the very end of `generate`. The seed files should still exist locally, so they may still make it in to the archive after `mt = MultiTable.restore; mt.generate(resume=True)`, unless the restored instance is running in some other location where the original working directory is not present. We consider this acceptable loss, since the seed files are not particularly useful beyond potentially for debugging purposes.