### PR TITLE
Add passthrough policy to transform configs

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 import networkx
 import pandas as pd
@@ -14,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 class MultiTableException(Exception):
     pass
+
+
+GretelModelConfig = Union[str, Path, Dict]
 
 
 @dataclass
@@ -172,6 +176,13 @@ class RelationalData:
             fks = self.graph.edges[table, parent]["via"]
             foreign_keys.extend(fks)
         return foreign_keys
+
+    def get_all_key_columns(self, table: str) -> List[str]:
+        key_columns = [fk.column_name for fk in self.get_foreign_keys(table)]
+        pk = self.get_primary_key(table)
+        if pk is not None:
+            key_columns.append(pk)
+        return key_columns
 
     def debug_summary(self) -> Dict[str, Any]:
         max_depth = dag_longest_path_length(self.graph)

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List
+
+from gretel_client.projects.models import read_model_config
+
+from gretel_trainer.relational.core import (
+    GretelModelConfig,
+    MultiTableException,
+    RelationalData,
+)
+
+
+def _model_name(workflow: str, table: str) -> str:
+    ok_table_name = table.replace("--", "__")
+    return f"{workflow}-{ok_table_name}"
+
+
+def make_synthetics_config(table: str, config: GretelModelConfig) -> Dict[str, Any]:
+    tailored_config = read_model_config(config)
+    tailored_config["name"] = _model_name("synthetics", table)
+    return tailored_config
+
+
+def make_transform_config(
+    rel_data: RelationalData, table: str, config: GretelModelConfig
+) -> Dict[str, Any]:
+    tailored_config = read_model_config(config)
+    tailored_config["name"] = _model_name("transforms", table)
+
+    key_columns = rel_data.get_all_key_columns(table)
+    if len(key_columns) > 0:
+        try:
+            model = tailored_config["models"][0]
+            try:
+                model_key = "transform"
+                xform = model[model_key]
+            except KeyError:
+                model_key = "transforms"
+                xform = model[model_key]
+            policies = xform["policies"]
+        except KeyError:
+            raise MultiTableException("Invalid transform config")
+
+        passthrough_policy = _passthrough_policy(key_columns)
+        adjusted_policies = [passthrough_policy] + policies
+
+        tailored_config["models"][0][model_key]["policies"] = adjusted_policies
+
+    return tailored_config
+
+
+def _passthrough_policy(columns: List[str]) -> Dict[str, Any]:
+    return {
+        "name": "ignore-keys",
+        "rules": [
+            {
+                "name": "ignore-key-columns",
+                "conditions": {"field_name": columns},
+                "transforms": [
+                    {
+                        "type": "passthrough",
+                    }
+                ],
+            }
+        ],
+    }

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -34,9 +34,14 @@ from gretel_trainer.relational.backup import (
     BackupTransformsTrain,
 )
 from gretel_trainer.relational.core import (
+    GretelModelConfig,
     MultiTableException,
     RelationalData,
     TableEvaluation,
+)
+from gretel_trainer.relational.model_config import (
+    make_synthetics_config,
+    make_transform_config,
 )
 from gretel_trainer.relational.report.report import ReportPresenter, ReportRenderer
 from gretel_trainer.relational.sdk_extras import (
@@ -49,8 +54,6 @@ from gretel_trainer.relational.sdk_extras import (
 )
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
-
-GretelModelConfig = Union[str, Path, Dict]
 
 MAX_REFRESH_ATTEMPTS = 3
 
@@ -454,9 +457,9 @@ class MultiTable:
 
     def train_transform_models(self, configs: Dict[str, GretelModelConfig]) -> None:
         for table, config in configs.items():
-            # Ensure consistent, friendly model name in Console
-            named_config = read_model_config(config)
-            named_config["name"] = _model_name("transforms", table)
+            transform_config = make_transform_config(
+                self.relational_data, table, config
+            )
 
             # Ensure consistent, friendly data source names in Console
             table_data = self.relational_data.get_table_data(table)
@@ -465,7 +468,7 @@ class MultiTable:
 
             # Create model
             model = self._project.create_model_obj(
-                model_config=named_config, data_source=str(transforms_train_path)
+                model_config=transform_config, data_source=str(transforms_train_path)
             )
             self._transforms_train.models[table] = model
 
@@ -670,16 +673,11 @@ class MultiTable:
 
         return training_paths
 
-    def _table_model_config(self, table_name: str) -> Dict:
-        config_dict = read_model_config(self._model_config)
-        config_dict["name"] = _model_name("synthetics", table_name)
-        return config_dict
-
     def _train_synthetics_models(self, training_data: Dict[str, Path]) -> None:
         for table_name, training_csv in training_data.items():
-            table_model_config = self._table_model_config(table_name)
+            synthetics_config = make_synthetics_config(table_name, self._model_config)
             model = self._project.create_model_obj(
-                model_config=table_model_config, data_source=str(training_csv)
+                model_config=synthetics_config, data_source=str(training_csv)
             )
             self._synthetics_train.models[table_name] = model
 
@@ -1183,11 +1181,6 @@ def _upload_gretel_backup(project: Project, path: str) -> None:
         key = artifact["key"]
         if key != latest and key.endswith("__gretel_backup.json"):
             project.delete_artifact(key)
-
-
-def _model_name(workflow: str, table: str) -> str:
-    ok_table_name = table.replace("--", "__")
-    return f"{workflow}-{ok_table_name}"
 
 
 def _timestamp() -> str:

--- a/tests/relational/test_model_config.py
+++ b/tests/relational/test_model_config.py
@@ -1,0 +1,50 @@
+from gretel_client.projects.models import read_model_config
+
+from gretel_trainer.relational.model_config import (
+    make_synthetics_config,
+    make_transform_config,
+)
+
+
+def test_synthetics_config_prepends_workflow():
+    config = make_synthetics_config("users", "synthetics/amplify")
+    assert config["name"] == "synthetics-users"
+
+
+def test_synthetics_config_handles_noncompliant_table_names():
+    config = make_synthetics_config("hello--world", "synthetics/amplify")
+    assert config["name"] == "synthetics-hello__world"
+
+
+def test_transforms_config_prepends_workflow(mutagenesis):
+    config = make_transform_config(mutagenesis, "atom", "transform/default")
+    assert config["name"] == "transforms-atom"
+
+
+def test_transforms_config_adds_passthrough_policy(mutagenesis):
+    def get_policies(config):
+        # default blueprint uses `transforms` model key
+        return config["models"][0]["transforms"]["policies"]
+
+    original = read_model_config("transform/default")
+    original_policies = get_policies(original)
+
+    xform_config = make_transform_config(mutagenesis, "atom", "transform/default")
+    xform_config_policies = get_policies(xform_config)
+
+    assert len(xform_config_policies) == len(original_policies) + 1
+    assert xform_config_policies[1:] == original_policies
+    assert xform_config_policies[0] == {
+        "name": "ignore-keys",
+        "rules": [
+            {
+                "name": "ignore-key-columns",
+                "conditions": {"field_name": ["molecule_id", "atom_id"]},
+                "transforms": [
+                    {
+                        "type": "passthrough",
+                    }
+                ],
+            }
+        ],
+    }

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -37,6 +37,9 @@ def test_mutagenesis_relational_data(mutagenesis):
     assert mutagenesis.get_primary_key("bond") is None
     assert mutagenesis.get_primary_key("atom") == "atom_id"
 
+    assert set(mutagenesis.get_all_key_columns("bond")) == {"atom1_id", "atom2_id"}
+    assert set(mutagenesis.get_all_key_columns("atom")) == {"atom_id", "molecule_id"}
+
 
 def test_add_foreign_key_checks_if_tables_exist():
     rel_data = RelationalData()


### PR DESCRIPTION
Relational Transforms requires user-supplied transform configs*. If such a config includes policies that match a primary or foreign key column name, those policies will be applied just like any other... but we don't want to do that, because Relational Transforms performs its own post-processing on key columns, and if any have been transformed by our models, we will have already corrupted the relationships between tables (and post-processing can't fix it).

This change modifies the transform configs supplied by the user, adding an initial passthrough policy that applies to all key columns on the table.

I tested this before and after with the [gdpr transforms config](https://raw.githubusercontent.com/gretelai/gdpr-helpers/main/src/config/transforms_config.yaml) and can confirm that on `main` we end up with no matching records between two tables in our `telecom` database (client and location), but when running this branch we preserve all PK/FK relationships between the two (an INNER join between the two tables does not drop any records).

Note: had to include some ugliness to support the two valid model keys (`transform` and `transforms`)—pretty sure this is unavoidable since we modify this config locally before submitting to the API, and both appear in various public templates/blueprints.

---

> \* Something to consider medium/longer-term: we could potentially default to using the gdpr transforms config linked above, instead of requiring users provide a transforms config. This would require changing the interface slightly, as currently the dict of `[table_name, xform_config]` passed to `train_transforms_models` currently dictates which tables we train transforms models.