### PR TITLE
Use legacy resolver arg for pip install in benchmark notebook

### DIFF
--- a/notebooks/benchmark.ipynb
+++ b/notebooks/benchmark.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U gretel-trainer"
+    "!pip install --use-deprecated=legacy-resolver -U gretel-trainer"
    ]
   },
   {


### PR DESCRIPTION
At least on my colab instance (and I guess on most environments), the `gretel-trainer` dep won't install without telling `pip` to use the legacy resolver.