### PR TITLE
Docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
 -r ../requirements.txt
-m2r
-sphinx==3.0.3
 docutils==0.17.1
+gretel-client
+jinja2<3.1
+m2r
 mistune==0.8.4
-sphinx-rtd-theme 
-gretel-client 
-jinja2<3.1 
 requests==2.25.0
+sphinx-rtd-theme
+sphinx==3.0.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,6 @@
--r ../requirements.txt
 docutils==0.17.1
-gretel-client
 jinja2<3.1
 m2r
 mistune==0.8.4
-requests==2.25.0
 sphinx-rtd-theme
 sphinx==3.0.3


### PR DESCRIPTION
We added `jinja2` as a dependency to Trainer's main `requirements.txt` file a while back, causing a conflict with the version required here for readthedocs. This PR drops the reference to that full requirements file, as well as requests and gretel-client, which I think are pretty obviously not needed for building markdown docs.