### PR TITLE
Hybrid trainer

### DIFF
--- a/notebooks/conditional-generation.py
+++ b/notebooks/conditional-generation.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from gretel_client import configure_session
 
 from gretel_trainer import Trainer
 from gretel_trainer.models import GretelLSTM, GretelACTGAN
@@ -19,6 +20,9 @@ seed_df = pd.DataFrame(data=[
     ["asian", "chinese", "F"]
 ], columns=["RACE", "ETHNICITY", "GENDER"])
 
+
+# Configure Gretel credentials
+configure_session(api_key="prompt", cache="yes", validate=True)
 
 # Train a model and conditionally generate data
 seed_fields = seed_df.columns.values.tolist()

--- a/notebooks/custom-example.py
+++ b/notebooks/custom-example.py
@@ -1,6 +1,11 @@
+from gretel_client import configure_session
+
 from gretel_trainer import Trainer
 from gretel_trainer.models import GretelLSTM, GretelACTGAN
 
+
+# Configure Gretel credentials
+configure_session(api_key="prompt", cache="yes", validate=True)
 
 dataset = "https://gretel-public-website.s3-us-west-2.amazonaws.com/datasets/USAdultIncome5k.csv"
 

--- a/notebooks/simple-conditional-generation.ipynb
+++ b/notebooks/simple-conditional-generation.ipynb
@@ -32,16 +32,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Configure Gretel credentials\n",
+        "from gretel_client import configure_session\n",
+        "\n",
+        "configure_session(api_key=\"prompt\", cache=\"yes\", validate=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Gh10cM4SiHPM"
+      },
+      "outputs": [],
       "source": [
         "# Train model\n",
         "model = trainer.Trainer()\n",
         "model.train(DATASET_PATH, seed_fields=SEED_FIELDS)"
-      ],
-      "metadata": {
-        "id": "Gh10cM4SiHPM"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",

--- a/notebooks/simple-example.py
+++ b/notebooks/simple-example.py
@@ -1,4 +1,8 @@
+from gretel_client import configure_session
 from gretel_trainer import Trainer
+
+# Configure Gretel credentials
+configure_session(api_key="prompt", cache="yes", validate=True)
 
 dataset = "https://gretel-public-website.s3-us-west-2.amazonaws.com/datasets/USAdultIncome5k.csv"
 

--- a/notebooks/trainer-examples.ipynb
+++ b/notebooks/trainer-examples.ipynb
@@ -14,6 +14,18 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Configure Gretel credentials\n",
+        "from gretel_client import configure_session\n",
+        "\n",
+        "configure_session(api_key=\"prompt\", cache=\"yes\", validate=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "rNI6TSbOCrEo"
       },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3~=1.20
-gretel-client>=0.15.9
+gretel-client>=0.16.0
 gretel-synthetics[utils]
 jinja2~=3.1
 networkx~=3.0


### PR DESCRIPTION
### What's here

#### Hybrid support
- Use the generic `submit` method on jobs (which relies on the session config, see more below)
- Skip artifact eviction when in hybrid mode (we can't delete hybrid artifacts, but we don't need to anyways because we don't have an artifact limit to worry about)

#### Lift configure_session out of Trainer constructor
Cloud vs. Hybrid is driven by the client config. Lifting this function out of the library code separates concerns and avoids cluttering the Trainer interface with configuration details. I updated all the (non-Benchmark/Relational) notebooks and examples to explicitly call `configure_session` first separately. (Relational coming in a separate PR.)
