### PR TITLE
Hybrid relational

### DIFF
--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -23,13 +23,7 @@
    "source": [
     "from gretel_client import configure_session\n",
     "\n",
-    "configure_session(\n",
-    "    api_key=\"prompt\",\n",
-    "    validate=True,\n",
-    "    cache=\"yes\",\n",
-    "    # default_runner=\"cloud\",\n",
-    "    # artifact_endpoint=\"cloud\",\n",
-    ")"
+    "configure_session(api_key=\"prompt\", cache=\"yes\", validate=True)"
    ]
   },
   {

--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -21,6 +21,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from gretel_client import configure_session\n",
+    "\n",
+    "configure_session(\n",
+    "    api_key=\"prompt\",\n",
+    "    validate=True,\n",
+    "    cache=\"yes\",\n",
+    "    # default_runner=\"cloud\",\n",
+    "    # artifact_endpoint=\"cloud\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# End-to-end synthetics example\n",
     "\n",
     "from gretel_trainer.relational import MultiTable, sqlite_conn\n",

--- a/src/gretel_trainer/relational/__init__.py
+++ b/src/gretel_trainer/relational/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+import gretel_trainer.relational.log
 from gretel_trainer.relational.connectors import (
     Connector,
     mariadb_conn,
@@ -10,20 +11,3 @@ from gretel_trainer.relational.connectors import (
 )
 from gretel_trainer.relational.core import RelationalData
 from gretel_trainer.relational.multi_table import MultiTable
-
-log_format = "%(levelname)s - %(asctime)s - %(message)s"
-time_format = "%Y-%m-%d %H:%M:%S"
-formatter = logging.Formatter(log_format, time_format)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-
-# Clear out any existing root handlers
-# (This prevents duplicate log output in Colab)
-for root_handler in logging.root.handlers:
-    logging.root.removeHandler(root_handler)
-
-# Configure relational loggers
-logger = logging.getLogger("gretel_trainer.relational")
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel("INFO")

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -11,6 +11,7 @@ from gretel_client.projects import Project
 
 @dataclass
 class ArtifactCollection:
+    hybrid: bool
     gretel_debug_summary: Optional[str] = None
     source_archive: Optional[str] = None
     synthetics_training_archive: Optional[str] = None
@@ -37,7 +38,10 @@ class ArtifactCollection:
         existing = self.transforms_outputs_archive
         self.transforms_outputs_archive = self._upload_file(project, path, existing)
 
-    def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> str:
+    def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> Optional[str]:
+        if self.hybrid:
+            return None
+
         latest = project.upload_artifact(path)
         if existing is not None:
             project.delete_artifact(existing)

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -41,6 +41,9 @@ class ArtifactCollection:
     def _upload_file(
         self, project: Project, path: str, existing: Optional[str]
     ) -> Optional[str]:
+        # We do not upload any of these artifacts in hybrid contexts because they are intended to be
+        # "singleton" objects, but we cannot list or delete items in users' artifact endpoints, so
+        # we would end up polluting their endpoints with many nearly-duplicative copies of these files.
         if self.hybrid:
             return None
 

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -38,7 +38,9 @@ class ArtifactCollection:
         existing = self.transforms_outputs_archive
         self.transforms_outputs_archive = self._upload_file(project, path, existing)
 
-    def _upload_file(self, project: Project, path: str, existing: Optional[str]) -> Optional[str]:
+    def _upload_file(
+        self, project: Project, path: str, existing: Optional[str]
+    ) -> Optional[str]:
         if self.hybrid:
             return None
 

--- a/src/gretel_trainer/relational/log.py
+++ b/src/gretel_trainer/relational/log.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 
 RELATIONAL = "gretel_trainer.relational"
 
@@ -17,3 +18,14 @@ logger.setLevel("INFO")
 # (This prevents duplicate log output in Colab)
 for root_handler in logging.root.handlers:
     logging.root.removeHandler(root_handler)
+
+
+@contextmanager
+def silent_logs():
+    logger = logging.getLogger(RELATIONAL)
+    current_level = logger.getEffectiveLevel()
+    logger.setLevel("CRITICAL")
+    try:
+        yield
+    finally:
+        logger.setLevel(current_level)

--- a/src/gretel_trainer/relational/log.py
+++ b/src/gretel_trainer/relational/log.py
@@ -1,0 +1,19 @@
+import logging
+
+RELATIONAL = "gretel_trainer.relational"
+
+log_format = "%(levelname)s - %(asctime)s - %(message)s"
+time_format = "%Y-%m-%d %H:%M:%S"
+formatter = logging.Formatter(log_format, time_format)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+
+logger = logging.getLogger(RELATIONAL)
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel("INFO")
+
+# Clear out any existing root handlers
+# (This prevents duplicate log output in Colab)
+for root_handler in logging.root.handlers:
+    logging.root.removeHandler(root_handler)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import pandas as pd
 import requests
 import smart_open
-from gretel_client import configure_session
 from gretel_client.config import RunnerMode, get_session_config
 from gretel_client.projects import Project, create_project, get_project
 from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status
@@ -82,7 +81,6 @@ class MultiTable:
         gretel_model (str, optional): The underlying Gretel model to use. Default and acceptable models vary based on strategy.
         project_display_name (str, optional): Display name in the console for a new Gretel project holding models and artifacts. Defaults to "multi-table".
         refresh_interval (int, optional): Frequency in seconds to poll Gretel Cloud for job statuses. Must be at least 30. Defaults to 60 (1m).
-        hybrid_artifact_endpoint (str, optional): Artifact endpoint to use when running in a hybrid deployment.
         backup (Backup, optional): Should not be supplied manually; instead use the `restore` classmethod.
     """
 
@@ -94,7 +92,6 @@ class MultiTable:
         gretel_model: Optional[str] = None,
         project_display_name: Optional[str] = None,
         refresh_interval: Optional[int] = None,
-        hybrid_artifact_endpoint: Optional[str] = None,
         backup: Optional[Backup] = None,
     ):
         self._strategy = _validate_strategy(strategy)
@@ -102,19 +99,6 @@ class MultiTable:
         self._gretel_model = model_name
         self._model_config = model_config
         self._set_refresh_interval(refresh_interval)
-
-        default_runner = None
-        if hybrid_artifact_endpoint is not None:
-            default_runner = "hybrid"
-
-        configure_session(
-            api_key="prompt",
-            cache="yes",
-            validate=True,
-            default_runner=default_runner,
-            artifact_endpoint=hybrid_artifact_endpoint,
-        )
-
         self.relational_data = relational_data
         self._artifact_collection = ArtifactCollection(hybrid=self._hybrid)
         self._latest_backup: Optional[Backup] = None

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -130,17 +130,18 @@ class MultiTable:
         self._artifact_collection = backup.artifact_collection
 
         # RelationalData
+        source_archive_path = self._working_dir / "source_tables.tar.gz"
         source_archive_id = backup.artifact_collection.source_archive
-        if source_archive_id is None:
+        if source_archive_id is not None:
+            self._extended_sdk.download_tar_artifact(
+                self._project,
+                source_archive_id,
+                source_archive_path,
+            )
+        if not source_archive_path.exists():
             raise MultiTableException(
                 "Cannot restore from backup: source archive is missing."
             )
-        source_archive_path = self._working_dir / "source_tables.tar.gz"
-        self._extended_sdk.download_tar_artifact(
-            self._project,
-            source_archive_id,
-            source_archive_path,
-        )
         with tarfile.open(source_archive_path, "r:gz") as tar:
             tar.extractall(path=self._working_dir)
         for table_name, table_backup in backup.relational_data.tables.items():
@@ -183,18 +184,19 @@ class MultiTable:
 
         logger.info("Restoring synthetics models")
 
+        synthetics_training_archive_path = (
+            self._working_dir / "synthetics_training.tar.gz"
+        )
         synthetics_training_archive_id = (
             self._artifact_collection.synthetics_training_archive
         )
         if synthetics_training_archive_id is not None:
-            synthetics_training_archive_path = (
-                self._working_dir / "synthetics_training.tar.gz"
-            )
             self._extended_sdk.download_tar_artifact(
                 self._project,
                 synthetics_training_archive_id,
                 synthetics_training_archive_path,
             )
+        if synthetics_training_archive_path.exists():
             with tarfile.open(synthetics_training_archive_path, "r:gz") as tar:
                 tar.extractall(path=self._working_dir)
 
@@ -244,20 +246,19 @@ class MultiTable:
 
         # Synthetics Generate
         ## First, download the outputs archive if present and extract the data.
+        synthetics_output_archive_path = self._working_dir / "synthetics_outputs.tar.gz"
         synthetics_outputs_archive_id = (
             self._artifact_collection.synthetics_outputs_archive
         )
         any_outputs = False
         if synthetics_outputs_archive_id is not None:
-            any_outputs = True
-            synthetics_output_archive_path = (
-                self._working_dir / "synthetics_outputs.tar.gz"
-            )
             self._extended_sdk.download_tar_artifact(
                 self._project,
                 synthetics_outputs_archive_id,
                 synthetics_output_archive_path,
             )
+        if synthetics_output_archive_path.exists():
+            any_outputs = True
             with tarfile.open(synthetics_output_archive_path, "r:gz") as tar:
                 tar.extractall(path=self._working_dir)
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -47,11 +47,9 @@ from gretel_trainer.relational.model_config import (
 from gretel_trainer.relational.report.report import ReportPresenter, ReportRenderer
 from gretel_trainer.relational.sdk_extras import (
     cautiously_refresh_status,
-    delete_data_source,
     download_file_artifact,
     download_tar_artifact,
     get_job_id,
-    room_in_project,
     sqs_score_from_full_report,
 )
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -39,6 +39,7 @@ from gretel_trainer.relational.core import (
     RelationalData,
     TableEvaluation,
 )
+from gretel_trainer.relational.log import silent_logs
 from gretel_trainer.relational.model_config import (
     make_evaluate_config,
     make_synthetics_config,
@@ -229,9 +230,14 @@ class MultiTable:
         ]
         for table in training_succeeded:
             model = self._synthetics_train.models[table]
-            self._strategy.update_evaluation_from_model(
-                table, self.evaluations, model, self._working_dir, self._extended_sdk
-            )
+            with silent_logs():
+                self._strategy.update_evaluation_from_model(
+                    table,
+                    self.evaluations,
+                    model,
+                    self._working_dir,
+                    self._extended_sdk,
+                )
 
         training_failed = [
             table

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -53,8 +54,10 @@ class ExtendedGretelSDK:
     ) -> None:
         download_link = gretel_object.get_artifact_link(artifact_name)
         try:
-            with open(out_path, "wb+") as out:
-                out.write(smart_open.open(download_link, "rb").read())
+            with smart_open.open(download_link) as src, smart_open.open(
+                out_path, "w"
+            ) as dest:
+                shutil.copyfileobj(src, dest)
         except:
             logger.warning(f"Failed to download `{artifact_name}`")
 

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -54,9 +54,9 @@ class ExtendedGretelSDK:
     ) -> None:
         download_link = gretel_object.get_artifact_link(artifact_name)
         try:
-            with smart_open.open(
-                download_link, "rb", ignore_ext=True
-            ) as src, smart_open.open(out_path, "wb", ignore_ext=True) as dest:
+            with smart_open.open(download_link, "rb") as src, smart_open.open(
+                out_path, "wb"
+            ) as dest:
                 shutil.copyfileobj(src, dest)
         except:
             logger.warning(f"Failed to download `{artifact_name}`")

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -54,9 +54,9 @@ class ExtendedGretelSDK:
     ) -> None:
         download_link = gretel_object.get_artifact_link(artifact_name)
         try:
-            with smart_open.open(download_link) as src, smart_open.open(
-                out_path, "w"
-            ) as dest:
+            with smart_open.open(
+                download_link, "rb", ignore_ext=True
+            ) as src, smart_open.open(out_path, "wb", ignore_ext=True) as dest:
                 shutil.copyfileobj(src, dest)
         except:
             logger.warning(f"Failed to download `{artifact_name}`")

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -18,95 +18,92 @@ logger = logging.getLogger(__name__)
 MAX_PROJECT_ARTIFACTS = 50
 
 
-def get_job_id(job: Job) -> Optional[str]:
-    if isinstance(job, Model):
-        return job.model_id
-    elif isinstance(job, RecordHandler):
-        return job.record_id
-    else:
-        raise MultiTableException("Unexpected job object")
+class ExtendedGretelSDK:
+    def __init__(self, hybrid: bool):
+        self._hybrid = hybrid
 
+    def get_job_id(self, job: Job) -> Optional[str]:
+        if isinstance(job, Model):
+            return job.model_id
+        elif isinstance(job, RecordHandler):
+            return job.record_id
+        else:
+            raise MultiTableException("Unexpected job object")
 
-def delete_data_source(project: Project, job: Job, hybrid: bool) -> None:
-    if not hybrid and job.data_source is not None:
-        project.delete_artifact(job.data_source)
+    def delete_data_source(self, project: Project, job: Job) -> None:
+        if not self._hybrid and job.data_source is not None:
+            project.delete_artifact(job.data_source)
 
+    def cautiously_refresh_status(
+        self, job: Job, key: str, refresh_attempts: Dict[str, int]
+    ) -> Status:
+        try:
+            job.refresh()
+            refresh_attempts[key] = 0
+        except:
+            refresh_attempts[key] = refresh_attempts[key] + 1
 
-def cautiously_refresh_status(
-    job: Job, key: str, refresh_attempts: Dict[str, int]
-) -> Status:
-    try:
-        job.refresh()
-        refresh_attempts[key] = 0
-    except:
-        refresh_attempts[key] = refresh_attempts[key] + 1
+        return job.status
 
-    return job.status
+    def download_file_artifact(
+        self,
+        gretel_object: Union[Project, Model],
+        artifact_name: str,
+        out_path: Union[str, Path],
+    ) -> None:
+        download_link = gretel_object.get_artifact_link(artifact_name)
+        try:
+            with open(out_path, "wb+") as out:
+                out.write(smart_open.open(download_link, "rb").read())
+        except:
+            logger.warning(f"Failed to download `{artifact_name}`")
 
+    def download_tar_artifact(
+        self, project: Project, artifact_name: str, out_path: Path
+    ) -> None:
+        download_link = project.get_artifact_link(artifact_name)
+        try:
+            response = requests.get(download_link)
+            if response.status_code == 200:
+                with open(out_path, "wb") as out:
+                    out.write(response.content)
+        except:
+            logger.warning(f"Failed to download `{artifact_name}`")
 
-def download_file_artifact(
-    gretel_object: Union[Project, Model],
-    artifact_name: str,
-    out_path: Union[str, Path],
-) -> None:
-    download_link = gretel_object.get_artifact_link(artifact_name)
-    try:
-        with open(out_path, "wb+") as out:
-            out.write(smart_open.open(download_link, "rb").read())
-    except:
-        logger.warning(f"Failed to download `{artifact_name}`")
+    def sqs_score_from_full_report(self, report: Dict[str, Any]) -> Optional[int]:
+        with suppress(KeyError):
+            for field_dict in report["summary"]:
+                if field_dict["field"] == "synthetic_data_quality_score":
+                    return field_dict["value"]
 
+    def get_record_handler_data(self, record_handler: RecordHandler) -> pd.DataFrame:
+        return pd.read_csv(record_handler.get_artifact_link("data"), compression="gzip")
 
-def download_tar_artifact(project: Project, artifact_name: str, out_path: Path) -> None:
-    download_link = project.get_artifact_link(artifact_name)
-    try:
-        response = requests.get(download_link)
-        if response.status_code == 200:
-            with open(out_path, "wb") as out:
-                out.write(response.content)
-    except:
-        logger.warning(f"Failed to download `{artifact_name}`")
+    def start_job_if_possible(
+        self,
+        job: Job,
+        table_name: str,
+        action: str,
+        project: Project,
+        number_of_artifacts: int,
+    ) -> None:
+        if job.data_source is None or self._room_in_project(
+            project, number_of_artifacts
+        ):
+            self._log_start(table_name, action)
+            job.submit()
+        else:
+            self._log_waiting(table_name, action)
 
+    def _room_in_project(self, project: Project, count: int) -> bool:
+        if self._hybrid:
+            return True
+        return len(project.artifacts) + count <= MAX_PROJECT_ARTIFACTS
 
-def sqs_score_from_full_report(report: Dict[str, Any]) -> Optional[int]:
-    with suppress(KeyError):
-        for field_dict in report["summary"]:
-            if field_dict["field"] == "synthetic_data_quality_score":
-                return field_dict["value"]
+    def _log_start(self, table_name: str, action: str) -> None:
+        logger.info(f"Starting {action} for `{table_name}`.")
 
-
-def get_record_handler_data(record_handler: RecordHandler) -> pd.DataFrame:
-    return pd.read_csv(record_handler.get_artifact_link("data"), compression="gzip")
-
-
-def start_job_if_possible(
-    job: Job,
-    table_name: str,
-    action: str,
-    project: Project,
-    number_of_artifacts: int,
-    hybrid: bool,
-) -> None:
-    if job.data_source is None or _room_in_project(
-        project, number_of_artifacts, hybrid
-    ):
-        _log_start(table_name, action)
-        job.submit()
-    else:
-        _log_waiting(table_name, action)
-
-
-def _room_in_project(project: Project, count: int, hybrid: bool) -> bool:
-    if hybrid:
-        return True
-    return len(project.artifacts) + count <= MAX_PROJECT_ARTIFACTS
-
-
-def _log_start(table_name: str, action: str) -> None:
-    logger.info(f"Starting {action} for `{table_name}`.")
-
-
-def _log_waiting(table_name: str, action: str) -> None:
-    logger.info(
-        f"Maximum concurrent relational jobs reached. Deferring start of `{table_name}` {action}."
-    )
+    def _log_waiting(self, table_name: str, action: str) -> None:
+        logger.info(
+            f"Maximum concurrent relational jobs reached. Deferring start of `{table_name}` {action}."
+        )

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -27,8 +27,8 @@ def get_job_id(job: Job) -> Optional[str]:
         raise MultiTableException("Unexpected job object")
 
 
-def delete_data_source(project: Project, job: Job) -> None:
-    if job.data_source is not None:
+def delete_data_source(project: Project, job: Job, hybrid: bool) -> None:
+    if not hybrid and job.data_source is not None:
         project.delete_artifact(job.data_source)
 
 
@@ -85,15 +85,20 @@ def start_job_if_possible(
     action: str,
     project: Project,
     number_of_artifacts: int,
+    hybrid: bool,
 ) -> None:
-    if job.data_source is None or _room_in_project(project, number_of_artifacts):
+    if job.data_source is None or _room_in_project(
+        project, number_of_artifacts, hybrid
+    ):
         _log_start(table_name, action)
-        job.submit_cloud()
+        job.submit()
     else:
         _log_waiting(table_name, action)
 
 
-def _room_in_project(project: Project, count: int = 1) -> bool:
+def _room_in_project(project: Project, count: int, hybrid: bool) -> bool:
+    if hybrid:
+        return True
     return len(project.artifacts) + count <= MAX_PROJECT_ARTIFACTS
 
 

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -27,10 +27,6 @@ def get_job_id(job: Job) -> Optional[str]:
         raise MultiTableException("Unexpected job object")
 
 
-def room_in_project(project: Project, count: int = 1) -> bool:
-    return len(project.artifacts) + count <= MAX_PROJECT_ARTIFACTS
-
-
 def delete_data_source(project: Project, job: Job) -> None:
     if job.data_source is not None:
         project.delete_artifact(job.data_source)
@@ -90,11 +86,15 @@ def start_job_if_possible(
     project: Project,
     number_of_artifacts: int,
 ) -> None:
-    if job.data_source is None or room_in_project(project, number_of_artifacts):
+    if job.data_source is None or _room_in_project(project, number_of_artifacts):
         _log_start(table_name, action)
         job.submit_cloud()
     else:
         _log_waiting(table_name, action)
+
+
+def _room_in_project(project: Project, count: int = 1) -> bool:
+    return len(project.artifacts) + count <= MAX_PROJECT_ARTIFACTS
 
 
 def _log_start(table_name: str, action: str) -> None:

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -309,9 +309,7 @@ class AncestralStrategy:
     ) -> None:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
-        common.download_artifacts(
-            evaluate_model, out_filepath, extended_sdk
-        )
+        common.download_artifacts(evaluate_model, out_filepath, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.individual_report_json = common.read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -281,7 +281,7 @@ class AncestralStrategy:
     ) -> None:
         logger.info(f"Downloading cross_table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
-        common.download_artifacts(model, out_filepath, table_name, extended_sdk)
+        common.download_artifacts(model, out_filepath, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_report_json = common.read_report_json_data(
@@ -310,7 +310,7 @@ class AncestralStrategy:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
         common.download_artifacts(
-            evaluate_model, out_filepath, table_name, extended_sdk
+            evaluate_model, out_filepath, extended_sdk
         )
 
         evaluation = evaluations[table_name]

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -13,6 +13,7 @@ from gretel_trainer.relational.core import (
     RelationalData,
     TableEvaluation,
 )
+from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 
 logger = logging.getLogger(__name__)
 
@@ -276,10 +277,11 @@ class AncestralStrategy:
         evaluations: Dict[str, TableEvaluation],
         model: Model,
         working_dir: Path,
+        extended_sdk: ExtendedGretelSDK,
     ) -> None:
         logger.info(f"Downloading cross_table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
-        common.download_artifacts(model, out_filepath, table_name)
+        common.download_artifacts(model, out_filepath, table_name, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_report_json = common.read_report_json_data(
@@ -303,10 +305,13 @@ class AncestralStrategy:
         evaluations: Dict[str, TableEvaluation],
         evaluate_model: Model,
         working_dir: Path,
+        extended_sdk: ExtendedGretelSDK,
     ) -> None:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
-        common.download_artifacts(evaluate_model, out_filepath, table_name)
+        common.download_artifacts(
+            evaluate_model, out_filepath, table_name, extended_sdk
+        )
 
         evaluation = evaluations[table_name]
         evaluation.individual_report_json = common.read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -9,12 +9,14 @@ from gretel_client.projects.models import Model
 from sklearn import preprocessing
 
 from gretel_trainer.relational.core import RelationalData
-from gretel_trainer.relational.sdk_extras import download_file_artifact
+from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 
 logger = logging.getLogger(__name__)
 
 
-def download_artifacts(model: Model, out_filepath: Path, table_name: str) -> None:
+def download_artifacts(
+    model: Model, out_filepath: Path, table_name: str, extended_sdk: ExtendedGretelSDK
+) -> None:
     """
     Downloads all model artifacts to a subdirectory in the working directory.
     Returns the artifact directory path when successful.
@@ -23,7 +25,7 @@ def download_artifacts(model: Model, out_filepath: Path, table_name: str) -> Non
 
     for filetype, artifact_name in legend.items():
         out_path = f"{out_filepath}.{filetype}"
-        download_file_artifact(model, artifact_name, out_path)
+        extended_sdk.download_file_artifact(model, artifact_name, out_path)
 
 
 def read_report_json_data(model: Model, report_path: Path) -> Optional[Dict]:

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -15,11 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def download_artifacts(
-    model: Model, out_filepath: Path, table_name: str, extended_sdk: ExtendedGretelSDK
+    model: Model, out_filepath: Path, extended_sdk: ExtendedGretelSDK
 ) -> None:
     """
     Downloads all model artifacts to a subdirectory in the working directory.
-    Returns the artifact directory path when successful.
     """
     legend = {"html": "report", "json": "report_json"}
 

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -13,6 +13,7 @@ from gretel_trainer.relational.core import (
     RelationalData,
     TableEvaluation,
 )
+from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 
 logger = logging.getLogger(__name__)
 
@@ -150,10 +151,11 @@ class IndependentStrategy:
         evaluations: Dict[str, TableEvaluation],
         model: Model,
         working_dir: Path,
+        extended_sdk: ExtendedGretelSDK,
     ) -> None:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
-        common.download_artifacts(model, out_filepath, table_name)
+        common.download_artifacts(model, out_filepath, table_name, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.individual_report_json = common.read_report_json_data(
@@ -192,10 +194,13 @@ class IndependentStrategy:
         evaluations: Dict[str, TableEvaluation],
         evaluate_model: Model,
         working_dir: Path,
+        extended_sdk: ExtendedGretelSDK,
     ) -> None:
         logger.info(f"Downloading cross table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
-        common.download_artifacts(evaluate_model, out_filepath, table_name)
+        common.download_artifacts(
+            evaluate_model, out_filepath, table_name, extended_sdk
+        )
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_report_json = common.read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -198,9 +198,7 @@ class IndependentStrategy:
     ) -> None:
         logger.info(f"Downloading cross table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
-        common.download_artifacts(
-            evaluate_model, out_filepath, extended_sdk
-        )
+        common.download_artifacts(evaluate_model, out_filepath, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.cross_table_report_json = common.read_report_json_data(

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -155,7 +155,7 @@ class IndependentStrategy:
     ) -> None:
         logger.info(f"Downloading individual evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_individual_evaluation_{table_name}"
-        common.download_artifacts(model, out_filepath, table_name, extended_sdk)
+        common.download_artifacts(model, out_filepath, extended_sdk)
 
         evaluation = evaluations[table_name]
         evaluation.individual_report_json = common.read_report_json_data(
@@ -199,7 +199,7 @@ class IndependentStrategy:
         logger.info(f"Downloading cross table evaluation reports for `{table_name}`.")
         out_filepath = working_dir / f"synthetics_cross_table_evaluation_{table_name}"
         common.download_artifacts(
-            evaluate_model, out_filepath, table_name, extended_sdk
+            evaluate_model, out_filepath, extended_sdk
         )
 
         evaluation = evaluations[table_name]

--- a/src/gretel_trainer/relational/task_runner.py
+++ b/src/gretel_trainer/relational/task_runner.py
@@ -11,7 +11,6 @@ from gretel_trainer.relational.sdk_extras import (
     cautiously_refresh_status,
     delete_data_source,
     get_job_id,
-    room_in_project,
     start_job_if_possible,
 )
 

--- a/src/gretel_trainer/relational/task_runner.py
+++ b/src/gretel_trainer/relational/task_runner.py
@@ -62,7 +62,7 @@ class Task(Protocol):
         ...
 
 
-def run_task(task: Task) -> None:
+def run_task(task: Task, hybrid: bool) -> None:
     refresh_attempts: Dict[str, int] = defaultdict(int)
     first_pass = True
 
@@ -84,6 +84,7 @@ def run_task(task: Task) -> None:
                     action=task.action,
                     project=task.project,
                     number_of_artifacts=task.artifacts_per_job,
+                    hybrid=hybrid,
                 )
                 continue
 
@@ -92,17 +93,17 @@ def run_task(task: Task) -> None:
             if refresh_attempts[table_name] >= MAX_REFRESH_ATTEMPTS:
                 _log_lost_contact(table_name)
                 task.handle_lost_contact(table_name)
-                delete_data_source(task.project, job)
+                delete_data_source(task.project, job, hybrid)
                 continue
 
             if status == Status.COMPLETED:
                 _log_success(table_name, task.action)
                 task.handle_completed(table_name, job)
-                delete_data_source(task.project, job)
+                delete_data_source(task.project, job, hybrid)
             elif status in END_STATES:
                 _log_failed(table_name, task.action)
                 task.handle_failed(table_name)
-                delete_data_source(task.project, job)
+                delete_data_source(task.project, job, hybrid)
             else:
                 _log_in_progress(table_name, status, task.action)
 

--- a/src/gretel_trainer/relational/tasks/common.py
+++ b/src/gretel_trainer/relational/tasks/common.py
@@ -26,7 +26,7 @@ class _MultiTable(Protocol):
         ...
 
     @property
-    def hybrid(self) -> bool:
+    def _hybrid(self) -> bool:
         ...
 
     def _backup(self) -> None:

--- a/src/gretel_trainer/relational/tasks/common.py
+++ b/src/gretel_trainer/relational/tasks/common.py
@@ -25,5 +25,9 @@ class _MultiTable(Protocol):
     def _strategy(self) -> Union[AncestralStrategy, IndependentStrategy]:
         ...
 
+    @property
+    def hybrid(self) -> bool:
+        ...
+
     def _backup(self) -> None:
         ...

--- a/src/gretel_trainer/relational/tasks/common.py
+++ b/src/gretel_trainer/relational/tasks/common.py
@@ -4,6 +4,7 @@ from gretel_client.projects.projects import Project
 from typing_extensions import Protocol
 
 from gretel_trainer.relational.core import RelationalData
+from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
 
@@ -26,7 +27,7 @@ class _MultiTable(Protocol):
         ...
 
     @property
-    def _hybrid(self) -> bool:
+    def _extended_sdk(self) -> ExtendedGretelSDK:
         ...
 
     def _backup(self) -> None:

--- a/src/gretel_trainer/relational/tasks/synthetics_run.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_run.py
@@ -145,6 +145,7 @@ class SyntheticsRunTask:
                 action=self.action,
                 project=self.project,
                 number_of_artifacts=self.artifacts_per_job,
+                hybrid=self.multitable.hybrid,
             )
 
         self.multitable._backup()

--- a/src/gretel_trainer/relational/tasks/synthetics_run.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_run.py
@@ -145,7 +145,7 @@ class SyntheticsRunTask:
                 action=self.action,
                 project=self.project,
                 number_of_artifacts=self.artifacts_per_job,
-                hybrid=self.multitable.hybrid,
+                hybrid=self.multitable._hybrid,
             )
 
         self.multitable._backup()

--- a/src/gretel_trainer/relational/tasks/transforms_run.py
+++ b/src/gretel_trainer/relational/tasks/transforms_run.py
@@ -5,7 +5,6 @@ from gretel_client.projects.jobs import Job
 from gretel_client.projects.projects import Project
 from gretel_client.projects.records import RecordHandler
 
-from gretel_trainer.relational.sdk_extras import get_record_handler_data
 from gretel_trainer.relational.tasks.common import _MultiTable
 
 
@@ -57,7 +56,9 @@ class TransformsRunTask:
         return self.record_handlers[table]
 
     def handle_completed(self, table: str, job: Job) -> None:
-        self.working_tables[table] = get_record_handler_data(job)
+        self.working_tables[
+            table
+        ] = self.multitable._extended_sdk.get_record_handler_data(job)
 
     def handle_failed(self, table: str) -> None:
         self.working_tables[table] = None

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -13,12 +13,6 @@ from gretel_trainer.relational.core import RelationalData
 EXAMPLE_DBS = Path(__file__).parent.resolve() / "example_dbs"
 
 
-@pytest.fixture(autouse=True)
-def patch_configure_session():
-    with patch("gretel_trainer.relational.multi_table.configure_session"):
-        yield
-
-
 @pytest.fixture()
 def project():
     with patch(

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -9,8 +9,14 @@ from sqlalchemy import create_engine
 
 from gretel_trainer.relational.connectors import Connector
 from gretel_trainer.relational.core import RelationalData
+from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 
 EXAMPLE_DBS = Path(__file__).parent.resolve() / "example_dbs"
+
+
+@pytest.fixture()
+def extended_sdk():
+    return ExtendedGretelSDK(hybrid=False)
 
 
 @pytest.fixture()

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -494,7 +494,9 @@ def test_post_process_synthetic_results(ecom):
     pdtest.assert_frame_equal(expected_users, processed_tables["users"])
 
 
-def test_uses_trained_model_to_update_cross_table_scores(report_json_dict):
+def test_uses_trained_model_to_update_cross_table_scores(
+    report_json_dict, extended_sdk
+):
     strategy = AncestralStrategy()
     evaluations = {
         "table_1": TableEvaluation(),
@@ -512,7 +514,7 @@ def test_uses_trained_model_to_update_cross_table_scores(report_json_dict):
             f.write(json.dumps(report_json_dict))
 
         strategy.update_evaluation_from_model(
-            "table_1", evaluations, model, working_dir
+            "table_1", evaluations, model, working_dir, extended_sdk
         )
 
     evaluation = evaluations["table_1"]
@@ -525,7 +527,7 @@ def test_uses_trained_model_to_update_cross_table_scores(report_json_dict):
 
 
 def test_falls_back_to_fetching_report_json_when_download_artifacts_fails(
-    report_json_dict,
+    report_json_dict, extended_sdk
 ):
     strategy = AncestralStrategy()
     evaluations = {
@@ -544,7 +546,7 @@ def test_falls_back_to_fetching_report_json_when_download_artifacts_fails(
         get_json.return_value = report_json_dict
 
         strategy.update_evaluation_from_model(
-            "table_1", evaluations, model, working_dir
+            "table_1", evaluations, model, working_dir, extended_sdk
         )
 
     evaluation = evaluations["table_1"]

--- a/tests/relational/test_artifacts.py
+++ b/tests/relational/test_artifacts.py
@@ -1,8 +1,9 @@
 import tarfile
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock
 
-from gretel_trainer.relational.artifacts import add_to_tar
+from gretel_trainer.relational.artifacts import ArtifactCollection, add_to_tar
 
 
 def test_makes_new_archive():
@@ -22,3 +23,39 @@ def test_appends_to_existing_archive():
 
         with tarfile.open(archive_path, "r:gz") as tar:
             assert len(tar.getnames()) == 2
+
+
+def test_uploads_path_to_project_and_stores_artifact_key():
+    ac = ArtifactCollection(hybrid=False)
+    project = Mock()
+    project.upload_artifact.return_value = "artifact_key"
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        ac.upload_gretel_debug_summary(project=project, path=tmpfile.name)
+
+    project.upload_artifact.assert_called_once_with(tmpfile.name)
+    assert ac.gretel_debug_summary == "artifact_key"
+
+
+def test_overwrites_project_artifacts():
+    ac = ArtifactCollection(hybrid=False, gretel_debug_summary="first_key")
+    project = Mock()
+    project.upload_artifact.return_value = "second_key"
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        ac.upload_gretel_debug_summary(project=project, path=tmpfile.name)
+
+    project.upload_artifact.assert_called_once_with(tmpfile.name)
+    project.delete_artifact.assert_called_once_with("first_key")
+    assert ac.gretel_debug_summary == "second_key"
+
+
+def test_does_not_upload_in_hybrid_mode():
+    ac = ArtifactCollection(hybrid=True)
+    project = Mock()
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        ac.upload_gretel_debug_summary(project=project, path=tmpfile.name)
+
+    project.upload_artifact.assert_not_called()
+    assert ac.gretel_debug_summary is None

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -76,6 +76,7 @@ def test_backup():
     artifact_collection = ArtifactCollection(
         gretel_debug_summary="gretel_abc__gretel_debug_summary.json",
         source_archive="gretel_abc_source_tables.tar.gz",
+        hybrid=False,
     )
     backup = Backup(
         project_name="my-project",

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -182,7 +182,7 @@ def test_post_processing_foreign_keys_with_skewed_frequencies_and_different_size
     assert fk_value_counts == [5, 5, 15, 30, 35, 60]
 
 
-def test_uses_trained_model_to_update_individual_scores(report_json_dict):
+def test_uses_trained_model_to_update_individual_scores(report_json_dict, extended_sdk):
     strategy = IndependentStrategy()
     evaluations = {
         "table_1": TableEvaluation(),
@@ -200,7 +200,7 @@ def test_uses_trained_model_to_update_individual_scores(report_json_dict):
             f.write(json.dumps(report_json_dict))
 
         strategy.update_evaluation_from_model(
-            "table_1", evaluations, model, working_dir
+            "table_1", evaluations, model, working_dir, extended_sdk
         )
 
     evaluation = evaluations["table_1"]
@@ -213,7 +213,7 @@ def test_uses_trained_model_to_update_individual_scores(report_json_dict):
 
 
 def test_falls_back_to_fetching_report_json_when_download_artifacts_fails(
-    report_json_dict,
+    report_json_dict, extended_sdk
 ):
     strategy = IndependentStrategy()
     evaluations = {
@@ -232,7 +232,7 @@ def test_falls_back_to_fetching_report_json_when_download_artifacts_fails(
         get_json.return_value = report_json_dict
 
         strategy.update_evaluation_from_model(
-            "table_1", evaluations, model, working_dir
+            "table_1", evaluations, model, working_dir, extended_sdk
         )
 
     evaluation = evaluations["table_1"]

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -126,6 +126,7 @@ def create_backup(
     artifact_collection = ArtifactCollection(
         gretel_debug_summary=ARTIFACTS["debug_summary"]["artifact_id"],
         source_archive=ARTIFACTS["source_archive"]["artifact_id"],
+        hybrid=False,
     )
     if training_archive_present:
         artifact_collection.synthetics_training_archive = ARTIFACTS[

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -326,386 +326,357 @@ def download_tar_artifact():
         yield download_tar_artifact
 
 
-def test_restore_not_yet_trained(project, pets, download_tar_artifact):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
-
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(project, download_tar_artifact, testsetup_dir, working_dir)
-        backup_file = create_backup(pets, working_dir)
-
-        # Restore a MultiTable instance, starting with only the backup file present in working_dir
-        assert os.listdir(working_dir) == ["_gretel_backup.json"]
-        mt = MultiTable.restore(backup_file)
-
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        assert len(os.listdir(working_dir)) == 5
-
-        # Debug summary is restored
-        assert os.path.exists(local_file(working_dir, "debug_summary"))
-        with open(local_file(working_dir, "debug_summary"), "r") as dbg:
-            assert json.load(dbg) == DEBUG_SUMMARY_CONTENT
-
-        # RelationalData is restored
-        assert os.path.exists(working_dir / "source_humans.csv")
-        assert os.path.exists(working_dir / "source_pets.csv")
-        assert mt.relational_data.debug_summary() == pets.debug_summary()
+@pytest.fixture(autouse=True)
+def working_dir():
+    with tempfile.TemporaryDirectory() as working_dir:
+        yield Path(working_dir)
 
 
-def test_restore_transforms(project, pets, download_tar_artifact):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+@pytest.fixture(autouse=True)
+def testsetup_dir():
+    with tempfile.TemporaryDirectory() as testsetup_dir:
+        yield Path(testsetup_dir)
 
-        transforms_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="completed",
-                setup_path=testsetup_dir,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="completed",
-                setup_path=testsetup_dir,
-            ),
-        }
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            transforms_models,
-        )
-        backup_file = create_backup(
-            pets, working_dir, transforms_models=transforms_models
-        )
+def test_restore_not_yet_trained(
+    project, pets, download_tar_artifact, working_dir, testsetup_dir
+):
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(project, download_tar_artifact, testsetup_dir, working_dir)
+    backup_file = create_backup(pets, working_dir)
 
-        mt = MultiTable.restore(backup_file)
+    # Restore a MultiTable instance, starting with only the backup file present in working_dir
+    assert os.listdir(working_dir) == ["_gretel_backup.json"]
+    mt = MultiTable.restore(backup_file)
 
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        assert len(os.listdir(working_dir)) == 5
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    assert len(os.listdir(working_dir)) == 5
 
-        # Transforms state is restored
-        assert len(mt._transforms_train.models) == 2
-        assert len(mt._transforms_train.lost_contact) == 0
+    # Debug summary is restored
+    assert os.path.exists(local_file(working_dir, "debug_summary"))
+    with open(local_file(working_dir, "debug_summary"), "r") as dbg:
+        assert json.load(dbg) == DEBUG_SUMMARY_CONTENT
+
+    # RelationalData is restored
+    assert os.path.exists(working_dir / "source_humans.csv")
+    assert os.path.exists(working_dir / "source_pets.csv")
+    assert mt.relational_data.debug_summary() == pets.debug_summary()
+
+
+def test_restore_transforms(
+    project, pets, download_tar_artifact, working_dir, testsetup_dir
+):
+    transforms_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="completed",
+            setup_path=testsetup_dir,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="completed",
+            setup_path=testsetup_dir,
+        ),
+    }
+
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        transforms_models,
+    )
+    backup_file = create_backup(pets, working_dir, transforms_models=transforms_models)
+
+    mt = MultiTable.restore(backup_file)
+
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    assert len(os.listdir(working_dir)) == 5
+
+    # Transforms state is restored
+    assert len(mt._transforms_train.models) == 2
+    assert len(mt._transforms_train.lost_contact) == 0
 
 
 def test_restore_synthetics_training_still_in_progress(
-    project, pets, download_tar_artifact
+    project, pets, download_tar_artifact, working_dir, testsetup_dir
 ):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+    synthetics_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="active",
+            setup_path=testsetup_dir,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="pending",
+            setup_path=testsetup_dir,
+        ),
+    }
 
-        synthetics_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="active",
-                setup_path=testsetup_dir,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="pending",
-                setup_path=testsetup_dir,
-            ),
-        }
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        synthetics_models,
+    )
+    backup_file = create_backup(pets, working_dir, synthetics_models=synthetics_models)
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            synthetics_models,
-        )
-        backup_file = create_backup(
-            pets, working_dir, synthetics_models=synthetics_models
-        )
-
-        with pytest.raises(MultiTableException):
-            mt = MultiTable.restore(backup_file)
+    with pytest.raises(MultiTableException):
+        mt = MultiTable.restore(backup_file)
 
 
 def test_restore_training_complete(
-    project, pets, report_json_dict, download_tar_artifact
+    project, pets, report_json_dict, download_tar_artifact, working_dir, testsetup_dir
 ):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+    synthetics_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="completed",
+            setup_path=testsetup_dir,
+            report_json=report_json_dict,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="completed",
+            setup_path=testsetup_dir,
+            report_json=report_json_dict,
+        ),
+    }
 
-        synthetics_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="completed",
-                setup_path=testsetup_dir,
-                report_json=report_json_dict,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="completed",
-                setup_path=testsetup_dir,
-                report_json=report_json_dict,
-            ),
-        }
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        synthetics_models,
+    )
+    backup_file = create_backup(
+        pets,
+        working_dir,
+        synthetics_models=synthetics_models,
+        training_archive_present=True,
+    )
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            synthetics_models,
-        )
-        backup_file = create_backup(
-            pets,
-            working_dir,
-            synthetics_models=synthetics_models,
-            training_archive_present=True,
-        )
+    mt = MultiTable.restore(backup_file)
 
-        mt = MultiTable.restore(backup_file)
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    # + Training archive + (2) Train CSVs + (4) Reports from models
+    assert len(os.listdir(working_dir)) == 12
 
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        # + Training archive + (2) Train CSVs + (4) Reports from models
-        assert len(os.listdir(working_dir)) == 12
+    # Training state is restored
+    assert os.path.exists(local_file(working_dir, "synthetics_training_archive"))
+    assert os.path.exists(local_file(working_dir, "train_humans"))
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_humans.json")
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_humans.html")
+    assert os.path.exists(local_file(working_dir, "train_pets"))
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_pets.json")
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_pets.html")
+    assert len(mt._synthetics_train.models) == 2
 
-        # Training state is restored
-        assert os.path.exists(local_file(working_dir, "synthetics_training_archive"))
-        assert os.path.exists(local_file(working_dir, "train_humans"))
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_humans.json"
-        )
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_humans.html"
-        )
-        assert os.path.exists(local_file(working_dir, "train_pets"))
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_pets.json"
-        )
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_pets.html"
-        )
-        assert len(mt._synthetics_train.models) == 2
-
-        # FIXME have {'humans': TableEvaluation(), 'pets': TableEvaluation()} here
-        assert mt.evaluations["humans"].individual_sqs == 95
-        assert mt.evaluations["humans"].cross_table_sqs is None
-        assert mt.evaluations["pets"].individual_sqs == 95
-        assert mt.evaluations["pets"].cross_table_sqs is None
+    assert mt.evaluations["humans"].individual_sqs == 95
+    assert mt.evaluations["humans"].cross_table_sqs is None
+    assert mt.evaluations["pets"].individual_sqs == 95
+    assert mt.evaluations["pets"].cross_table_sqs is None
 
 
 def test_restore_training_one_failed(
-    project, pets, report_json_dict, download_tar_artifact
+    project, pets, report_json_dict, download_tar_artifact, working_dir, testsetup_dir
 ):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+    synthetics_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="error",
+            setup_path=testsetup_dir,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="completed",
+            setup_path=testsetup_dir,
+            report_json=report_json_dict,
+        ),
+    }
 
-        synthetics_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="error",
-                setup_path=testsetup_dir,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="completed",
-                setup_path=testsetup_dir,
-                report_json=report_json_dict,
-            ),
-        }
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        synthetics_models,
+    )
+    backup_file = create_backup(
+        pets,
+        working_dir,
+        synthetics_models=synthetics_models,
+        training_archive_present=True,
+    )
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            synthetics_models,
-        )
-        backup_file = create_backup(
-            pets,
-            working_dir,
-            synthetics_models=synthetics_models,
-            training_archive_present=True,
-        )
+    mt = MultiTable.restore(backup_file)
 
-        mt = MultiTable.restore(backup_file)
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    # Training archive + (2) Train CSVs + (2) Reports from model
+    assert len(os.listdir(working_dir)) == 10
 
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        # Training archive + (2) Train CSVs + (2) Reports from model
-        assert len(os.listdir(working_dir)) == 10
+    # Training state is restored
+    assert os.path.exists(local_file(working_dir, "synthetics_training_archive"))
+    ## We do expect the training CSV to be present, extracted from the training archive...
+    assert os.path.exists(local_file(working_dir, "train_humans"))
+    ## ...but we should not see evaluation reports because the table failed to train.
 
-        # Training state is restored
-        assert os.path.exists(local_file(working_dir, "synthetics_training_archive"))
-        ## We do expect the training CSV to be present, extracted from the training archive...
-        assert os.path.exists(local_file(working_dir, "train_humans"))
-        ## ...but we should not see evaluation reports because the table failed to train.
+    assert not os.path.exists(
+        working_dir / "synthetics_individual_evaluation_humans.json"
+    )
+    assert not os.path.exists(
+        working_dir / "synthetics_individual_evaluation_humans.html"
+    )
 
-        assert not os.path.exists(
-            working_dir / "synthetics_individual_evaluation_humans.json"
-        )
-        assert not os.path.exists(
-            working_dir / "synthetics_individual_evaluation_humans.html"
-        )
+    assert os.path.exists(local_file(working_dir, "train_pets"))
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_pets.json")
+    assert os.path.exists(working_dir / "synthetics_individual_evaluation_pets.html")
+    assert len(mt._synthetics_train.models) == 2
 
-        assert os.path.exists(local_file(working_dir, "train_pets"))
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_pets.json"
-        )
-        assert os.path.exists(
-            working_dir / "synthetics_individual_evaluation_pets.html"
-        )
-        assert len(mt._synthetics_train.models) == 2
-
-        assert mt.evaluations["humans"].individual_sqs is None
-        assert mt.evaluations["humans"].cross_table_sqs is None
-        assert mt.evaluations["pets"].individual_sqs == 95
-        assert mt.evaluations["pets"].cross_table_sqs is None
+    assert mt.evaluations["humans"].individual_sqs is None
+    assert mt.evaluations["humans"].cross_table_sqs is None
+    assert mt.evaluations["pets"].individual_sqs == 95
+    assert mt.evaluations["pets"].cross_table_sqs is None
 
 
 def test_restore_generate_completed(
-    project, pets, report_json_dict, download_tar_artifact
+    project, pets, report_json_dict, download_tar_artifact, working_dir, testsetup_dir
 ):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+    synthetics_record_handlers = {
+        "humans": make_mock_record_handler(name="humans", status="completed"),
+        "pets": make_mock_record_handler(name="pets", status="completed"),
+    }
 
-        synthetics_record_handlers = {
-            "humans": make_mock_record_handler(name="humans", status="completed"),
-            "pets": make_mock_record_handler(name="pets", status="completed"),
-        }
+    synthetics_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="completed",
+            setup_path=testsetup_dir,
+            record_handler=synthetics_record_handlers["humans"],
+            report_json=report_json_dict,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="completed",
+            setup_path=testsetup_dir,
+            record_handler=synthetics_record_handlers["pets"],
+            report_json=report_json_dict,
+        ),
+    }
 
-        synthetics_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="completed",
-                setup_path=testsetup_dir,
-                record_handler=synthetics_record_handlers["humans"],
-                report_json=report_json_dict,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="completed",
-                setup_path=testsetup_dir,
-                record_handler=synthetics_record_handlers["pets"],
-                report_json=report_json_dict,
-            ),
-        }
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        synthetics_models,
+    )
+    backup_file = create_backup(
+        pets,
+        working_dir,
+        synthetics_models=synthetics_models,
+        synthetics_record_handlers=synthetics_record_handlers,
+        training_archive_present=True,
+        output_archive_present=True,
+    )
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            synthetics_models,
-        )
-        backup_file = create_backup(
-            pets,
-            working_dir,
-            synthetics_models=synthetics_models,
-            synthetics_record_handlers=synthetics_record_handlers,
-            training_archive_present=True,
-            output_archive_present=True,
-        )
+    mt = MultiTable.restore(backup_file)
 
-        mt = MultiTable.restore(backup_file)
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    # + Training archive + (2) Train CSVs + (4) Reports from models
+    # + Outputs archive + Previous run subdirectory
+    assert len(os.listdir(working_dir)) == 14
 
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        # + Training archive + (2) Train CSVs + (4) Reports from models
-        # + Outputs archive + Previous run subdirectory
-        assert len(os.listdir(working_dir)) == 14
-
-        # Generate state is restored
-        assert os.path.exists(working_dir / "run-id" / "synth_humans.csv")
-        assert os.path.exists(
-            working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.json"
-        )
-        assert os.path.exists(
-            working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.html"
-        )
-        assert os.path.exists(working_dir / "run-id" / "synth_pets.csv")
-        assert os.path.exists(
-            working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.json"
-        )
-        assert os.path.exists(
-            working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.html"
-        )
-        assert mt._synthetics_run is not None
-        assert len(mt.synthetic_output_tables) == 2
-        assert mt.evaluations["humans"].individual_sqs == 95
-        assert mt.evaluations["humans"].cross_table_sqs == 95
-        assert mt.evaluations["pets"].individual_sqs == 95
-        assert mt.evaluations["pets"].cross_table_sqs == 95
+    # Generate state is restored
+    assert os.path.exists(working_dir / "run-id" / "synth_humans.csv")
+    assert os.path.exists(
+        working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.json"
+    )
+    assert os.path.exists(
+        working_dir / "run-id" / "synthetics_cross_table_evaluation_humans.html"
+    )
+    assert os.path.exists(working_dir / "run-id" / "synth_pets.csv")
+    assert os.path.exists(
+        working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.json"
+    )
+    assert os.path.exists(
+        working_dir / "run-id" / "synthetics_cross_table_evaluation_pets.html"
+    )
+    assert mt._synthetics_run is not None
+    assert len(mt.synthetic_output_tables) == 2
+    assert mt.evaluations["humans"].individual_sqs == 95
+    assert mt.evaluations["humans"].cross_table_sqs == 95
+    assert mt.evaluations["pets"].individual_sqs == 95
+    assert mt.evaluations["pets"].cross_table_sqs == 95
 
 
 def test_restore_generate_in_progress(
-    project, pets, report_json_dict, download_tar_artifact
+    project, pets, report_json_dict, download_tar_artifact, working_dir, testsetup_dir
 ):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
-        working_dir = Path(working_dir)
-        testsetup_dir = Path(testsetup_dir)
+    synthetics_record_handlers = {
+        "humans": make_mock_record_handler(name="humans", status="completed"),
+        "pets": make_mock_record_handler(name="pets", status="completed"),
+    }
 
-        synthetics_record_handlers = {
-            "humans": make_mock_record_handler(name="humans", status="completed"),
-            "pets": make_mock_record_handler(name="pets", status="completed"),
-        }
+    synthetics_models = {
+        "humans": make_mock_model(
+            name="humans",
+            status="completed",
+            setup_path=testsetup_dir,
+            record_handler=synthetics_record_handlers["humans"],
+            report_json=report_json_dict,
+        ),
+        "pets": make_mock_model(
+            name="pets",
+            status="completed",
+            setup_path=testsetup_dir,
+            record_handler=synthetics_record_handlers["pets"],
+            report_json=report_json_dict,
+        ),
+    }
 
-        synthetics_models = {
-            "humans": make_mock_model(
-                name="humans",
-                status="completed",
-                setup_path=testsetup_dir,
-                record_handler=synthetics_record_handlers["humans"],
-                report_json=report_json_dict,
-            ),
-            "pets": make_mock_model(
-                name="pets",
-                status="completed",
-                setup_path=testsetup_dir,
-                record_handler=synthetics_record_handlers["pets"],
-                report_json=report_json_dict,
-            ),
-        }
+    create_standin_project_artifacts(pets, testsetup_dir)
+    configure_mocks(
+        project,
+        download_tar_artifact,
+        testsetup_dir,
+        working_dir,
+        synthetics_models,
+    )
+    backup_file = create_backup(
+        pets,
+        working_dir,
+        synthetics_models=synthetics_models,
+        synthetics_record_handlers=synthetics_record_handlers,
+        training_archive_present=True,
+        output_archive_present=False,
+    )
 
-        create_standin_project_artifacts(pets, testsetup_dir)
-        configure_mocks(
-            project,
-            download_tar_artifact,
-            testsetup_dir,
-            working_dir,
-            synthetics_models,
-        )
-        backup_file = create_backup(
-            pets,
-            working_dir,
-            synthetics_models=synthetics_models,
-            synthetics_record_handlers=synthetics_record_handlers,
-            training_archive_present=True,
-            output_archive_present=False,
-        )
+    mt = MultiTable.restore(backup_file)
 
-        mt = MultiTable.restore(backup_file)
+    # Backup + Debug summary + Source archive + (2) Source CSVs
+    # + Training archive + (2) Train CSVs + (4) Reports from models
+    assert len(os.listdir(working_dir)) == 12
 
-        # Backup + Debug summary + Source archive + (2) Source CSVs
-        # + Training archive + (2) Train CSVs + (4) Reports from models
-        assert len(os.listdir(working_dir)) == 12
-
-        # Generate state is partially restored
-        assert mt._synthetics_run == SyntheticsRun(
-            identifier="run-id",
-            preserved=[],
-            record_size_ratio=1.0,
-            lost_contact=[],
-            missing_model=[],
-            record_handlers=synthetics_record_handlers,
-        )
-        assert len(mt.synthetic_output_tables) == 0
-        assert mt.evaluations["humans"].individual_sqs == 95
-        assert mt.evaluations["humans"].cross_table_sqs is None
-        assert mt.evaluations["pets"].individual_sqs == 95
-        assert mt.evaluations["pets"].cross_table_sqs is None
+    # Generate state is partially restored
+    assert mt._synthetics_run == SyntheticsRun(
+        identifier="run-id",
+        preserved=[],
+        record_size_ratio=1.0,
+        lost_contact=[],
+        missing_model=[],
+        record_handlers=synthetics_record_handlers,
+    )
+    assert len(mt.synthetic_output_tables) == 0
+    assert mt.evaluations["humans"].individual_sqs == 95
+    assert mt.evaluations["humans"].cross_table_sqs is None
+    assert mt.evaluations["pets"].individual_sqs == 95
+    assert mt.evaluations["pets"].cross_table_sqs is None

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -318,10 +318,16 @@ def configure_mocks(
     )
 
 
-def test_restore_not_yet_trained(project, pets):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
+@pytest.fixture(autouse=True)
+def download_tar_artifact():
+    with patch(
+        "gretel_trainer.relational.sdk_extras.ExtendedGretelSDK.download_tar_artifact"
     ) as download_tar_artifact:
+        yield download_tar_artifact
+
+
+def test_restore_not_yet_trained(project, pets, download_tar_artifact):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -347,10 +353,8 @@ def test_restore_not_yet_trained(project, pets):
         assert mt.relational_data.debug_summary() == pets.debug_summary()
 
 
-def test_restore_transforms(project, pets):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_transforms(project, pets, download_tar_artifact):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -389,10 +393,10 @@ def test_restore_transforms(project, pets):
         assert len(mt._transforms_train.lost_contact) == 0
 
 
-def test_restore_synthetics_training_still_in_progress(project, pets):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_synthetics_training_still_in_progress(
+    project, pets, download_tar_artifact
+):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -425,10 +429,10 @@ def test_restore_synthetics_training_still_in_progress(project, pets):
             mt = MultiTable.restore(backup_file)
 
 
-def test_restore_training_complete(project, pets, report_json_dict):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_training_complete(
+    project, pets, report_json_dict, download_tar_artifact
+):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -493,10 +497,10 @@ def test_restore_training_complete(project, pets, report_json_dict):
         assert mt.evaluations["pets"].cross_table_sqs is None
 
 
-def test_restore_training_one_failed(project, pets, report_json_dict):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_training_one_failed(
+    project, pets, report_json_dict, download_tar_artifact
+):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -563,10 +567,10 @@ def test_restore_training_one_failed(project, pets, report_json_dict):
         assert mt.evaluations["pets"].cross_table_sqs is None
 
 
-def test_restore_generate_completed(project, pets, report_json_dict):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_generate_completed(
+    project, pets, report_json_dict, download_tar_artifact
+):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 
@@ -639,10 +643,10 @@ def test_restore_generate_completed(project, pets, report_json_dict):
         assert mt.evaluations["pets"].cross_table_sqs == 95
 
 
-def test_restore_generate_in_progress(project, pets, report_json_dict):
-    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir, patch(
-        "gretel_trainer.relational.multi_table.download_tar_artifact"
-    ) as download_tar_artifact:
+def test_restore_generate_in_progress(
+    project, pets, report_json_dict, download_tar_artifact
+):
+    with tempfile.TemporaryDirectory() as working_dir, tempfile.TemporaryDirectory() as testsetup_dir:
         working_dir = Path(working_dir)
         testsetup_dir = Path(testsetup_dir)
 

--- a/tests/relational/test_synthetics_run_task.py
+++ b/tests/relational/test_synthetics_run_task.py
@@ -23,6 +23,7 @@ class MockMultiTable:
     _refresh_interval: int = 0
     _project: Project = Mock(artifacts=[])
     _strategy: Union[AncestralStrategy, IndependentStrategy] = AncestralStrategy()
+    hybrid: bool = False
 
     def _backup(self) -> None:
         pass
@@ -126,7 +127,7 @@ def test_starts_jobs_for_ready_tables(pets, tmpdir):
     task.synthetics_train.models[
         "humans"
     ].create_record_handler_obj.assert_called_once()
-    task.synthetics_run.record_handlers["humans"].submit_cloud.assert_called_once()
+    task.synthetics_run.record_handlers["humans"].submit.assert_called_once()
 
 
 def test_defers_jobs_if_no_room(pets, tmpdir):
@@ -146,7 +147,7 @@ def test_defers_jobs_if_no_room(pets, tmpdir):
     task.synthetics_train.models[
         "humans"
     ].create_record_handler_obj.assert_called_once()
-    task.synthetics_run.record_handlers["humans"].submit_cloud.assert_not_called()
+    task.synthetics_run.record_handlers["humans"].submit.assert_not_called()
 
 
 def test_does_not_restart_existing_deferred_jobs(pets, tmpdir):
@@ -163,7 +164,7 @@ def test_does_not_restart_existing_deferred_jobs(pets, tmpdir):
     task.synthetics_train.models[
         "humans"
     ].create_record_handler_obj.assert_called_once()
-    task.synthetics_run.record_handlers["humans"].submit_cloud.assert_not_called()
+    task.synthetics_run.record_handlers["humans"].submit.assert_not_called()
 
     task.synthetics_train.models["humans"].reset_mock()
 

--- a/tests/relational/test_synthetics_run_task.py
+++ b/tests/relational/test_synthetics_run_task.py
@@ -10,7 +10,10 @@ import pytest
 from gretel_client.projects.projects import Project
 
 from gretel_trainer.relational.core import RelationalData
-from gretel_trainer.relational.sdk_extras import MAX_PROJECT_ARTIFACTS
+from gretel_trainer.relational.sdk_extras import (
+    MAX_PROJECT_ARTIFACTS,
+    ExtendedGretelSDK,
+)
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
 from gretel_trainer.relational.tasks import SyntheticsRunTask
@@ -23,7 +26,7 @@ class MockMultiTable:
     _refresh_interval: int = 0
     _project: Project = Mock(artifacts=[])
     _strategy: Union[AncestralStrategy, IndependentStrategy] = AncestralStrategy()
-    _hybrid: bool = False
+    _extended_sdk: ExtendedGretelSDK = ExtendedGretelSDK(hybrid=False)
 
     def _backup(self) -> None:
         pass
@@ -105,7 +108,7 @@ def test_runs_post_processing_when_table_completes(pets, tmpdir):
     task.multitable._strategy = MockStrategy()  # type:ignore
 
     with patch(
-        "gretel_trainer.relational.tasks.synthetics_run.get_record_handler_data"
+        "gretel_trainer.relational.sdk_extras.ExtendedGretelSDK.get_record_handler_data"
     ) as get_rh_data:
         get_rh_data.return_value = raw_df
         task.handle_completed("table", Mock())

--- a/tests/relational/test_synthetics_run_task.py
+++ b/tests/relational/test_synthetics_run_task.py
@@ -23,7 +23,7 @@ class MockMultiTable:
     _refresh_interval: int = 0
     _project: Project = Mock(artifacts=[])
     _strategy: Union[AncestralStrategy, IndependentStrategy] = AncestralStrategy()
-    hybrid: bool = False
+    _hybrid: bool = False
 
     def _backup(self) -> None:
         pass

--- a/tests/relational/test_task_runner.py
+++ b/tests/relational/test_task_runner.py
@@ -80,7 +80,7 @@ def test_one_successful_model(get_job_id, delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.iteration_count == 2
     assert task.completed == ["table"]
@@ -99,7 +99,7 @@ def test_one_failed_model(get_job_id, delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.iteration_count == 2
     assert task.completed == []
@@ -120,7 +120,7 @@ def test_model_taking_awhile(get_job_id, delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.iteration_count == 3
     assert task.completed == ["table"]
@@ -140,7 +140,7 @@ def test_lose_contact_with_model(get_job_id, delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     # Bail after refresh fails MAX_REFRESH_ATTEMPTS times
     assert task.iteration_count == 4
@@ -164,7 +164,7 @@ def test_refresh_status_can_tolerate_blips(get_job_id, delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.iteration_count == 3
     assert task.completed == ["table"]
@@ -194,7 +194,7 @@ def test_defers_submission_if_no_room_in_project(get_job_id, delete_data_source)
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.iteration_count == 4
     assert task.completed == ["table"]
@@ -220,16 +220,16 @@ def test_several_models(delete_data_source):
         project=project,
         models=models,
     )
-    run_task(task)
+    run_task(task, hybrid=False)
 
     assert task.completed == ["completed"]
     assert set(task.failed) == {"error", "cancelled", "lost"}
     delete_data_source.assert_has_calls(
         [
-            call(project, completed_model),
-            call(project, error_model),
-            call(project, cancelled_model),
-            call(project, lost_model),
+            call(project, completed_model, False),
+            call(project, error_model, False),
+            call(project, cancelled_model, False),
+            call(project, lost_model, False),
         ],
         any_order=True,
     )


### PR DESCRIPTION
### Similarities to [Trainer PR](https://github.com/gretelai/trainer/pull/86)
These changes will also require gretel-client 0.16.0, which I specified in the requirements file in the PR for trainer. I'll rebase this PR atop that one once it lands.

As with Trainer, I've lifted `configure_session` out of the library code. We should add a `configure_session` cell to the UCC notebooks.

### Relational artifacts
We do not upload relational-specific artifacts in hybrid mode. This includes the debug summary, backup file, and archive files (source, xforms outputs, synthetics training, synthetics outputs). The reason for this is that all of these relational artifacts are intended to be "singleton" objects that get overwritten when/as state changes. Examples:
- backup file: we take backup snapshots quite often throughout all processes
- xforms/synthetics outputs archives: each time you run record handlers (e.g. synthetics `generate`) we add that run's data to a subdirectory in the archive; the full history of runs is stored in the tar file
- source archive: changes the least often, but it will change if you run transforms with `in_place=True` or if you retrain synthetics tables

In hybrid contexts, we cannot list or delete project artifacts, so there is no way for us to _overwrite_ these files in the user's bucket. We'd end up polluting their bucket with a ton of nearly-duplicate-named files (e.g. `gretel_{uuid}_synthetics_outputs.tar.gz` and an inordinate amount of `gretel_{uuid}__gretel_backup.json` files) with no obvious way to know which is the latest.

Note: this limits the restore functionality a bit. In cloud context, we have artifact IDs for these and can download them from the project, so as long as you have a backup JSON file on hand you can restore "from anywhere", even a separate machine. In hybrid context, we are reliant on the files in the local working directory.

### Refactoring diffs
A good chunk of the diff here is due to grouping all the functions from `sdk_extras.py` into a class. (This prevents us from having to pass around `hybrid: bool` flags all over the place.)

I also introduced a pair of fixtures to the restore unit tests to reduce duplication (and save a level of indentation 😃), so that file looks noisier than it really is—none of the tests changed functionally (and one was added).