### PR TITLE
Convenience modifications to b2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ black
 isort
 lxml
 pandas-stubs
-pyright
+pyright==1.1.305
 pytest

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -5,7 +5,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from gretel_client import configure_session
@@ -84,9 +84,16 @@ class Comparison:
         working_dir: Optional[str] = None,
         additional_report_scores: Optional[List[str]] = None,
     ):
-        model_instances = [m() if isclass(m) else m for m in models]
-        self.gretel_models = [m for m in model_instances if isinstance(m, GretelModel)]
-        self.custom_models = [m for m in model_instances if not isinstance(m, GretelModel)]
+        model_instances = [
+            cast(Union[GretelModel, CustomModel], m() if isclass(m) else m)
+            for m in models
+        ]
+        self.gretel_models = [
+            m for m in model_instances if isinstance(m, GretelModel)
+        ]
+        self.custom_models = [
+            m for m in model_instances if not isinstance(m, GretelModel)
+        ]
 
         project_display_name = project_display_name or _default_name()
         working_dir = working_dir or project_display_name

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import logging
-import multiprocessing as mp
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
-from multiprocessing.managers import DictProxy
+from inspect import isclass
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from gretel_client import configure_session
@@ -33,9 +32,22 @@ logger = logging.getLogger(__name__)
 
 RUN_IDENTIFIER_SEPARATOR = "-"
 
+ALL_REPORT_SCORES = {
+    "SQS": "synthetic_data_quality_score",
+    "FCS": "field_correlation_stability",
+    "PCS": "principal_component_stability",
+    "FDS": "field_distribution_stability",
+    "PPL": "privacy_protection_level",
+}
+
 
 DatasetTypes = Union[CustomDataset, GretelDataset]
-ModelTypes = Union[Type[CustomModel], Type[GretelModel]]
+ModelTypes = Union[
+    CustomModel, Type[CustomModel],
+    GretelModel, Type[GretelModel],
+]
+
+FutureKeyT = Union[str, Tuple[str, str]]
 
 
 def compare(
@@ -46,6 +58,7 @@ def compare(
     trainer: bool = False,
     refresh_interval: int = 15,
     working_dir: Optional[str] = None,
+    additional_report_scores: Optional[List[str]] = None,
 ) -> Comparison:
     comparison = Comparison(
         datasets=datasets,
@@ -54,6 +67,7 @@ def compare(
         trainer=trainer,
         refresh_interval=refresh_interval,
         working_dir=working_dir,
+        additional_report_scores=additional_report_scores,
     )
     return comparison.prepare().execute()
 
@@ -68,9 +82,11 @@ class Comparison:
         trainer: bool = False,
         refresh_interval: int = 15,
         working_dir: Optional[str] = None,
+        additional_report_scores: Optional[List[str]] = None,
     ):
-        self.gretel_models = [m() for m in models if issubclass(m, GretelModel)]
-        self.custom_models = [m() for m in models if not issubclass(m, GretelModel)]
+        model_instances = [m() if isclass(m) else m for m in models]
+        self.gretel_models = [m for m in model_instances if isinstance(m, GretelModel)]
+        self.custom_models = [m for m in model_instances if not isinstance(m, GretelModel)]
 
         project_display_name = project_display_name or _default_name()
         working_dir = working_dir or project_display_name
@@ -89,14 +105,20 @@ class Comparison:
         self.datasets = [
             _make_dataset(dataset, self.config.working_dir) for dataset in datasets
         ]
-        self._gretel_executors: Dict[str, Executor] = {}
-        self._custom_executors: Dict[str, Executor] = {}
+        self._gretel_executors: Dict[Tuple[str, str], Executor] = {}
+        self._custom_executors: Dict[Tuple[str, str], Executor] = {}
         self.trainer_project_names: Dict[str, str] = {}
         self.thread_pool = ThreadPoolExecutor(5)
-        self.futures: Dict[str, Future] = {}
+        self.futures: Dict[FutureKeyT, Future] = {}
+
+        self._extra_report_scores = {
+            score_name: ALL_REPORT_SCORES[score_name]
+            for score_name in (additional_report_scores or [])
+            if score_name != "SQS"
+        }
 
     @property
-    def executors(self) -> Dict[str, Executor]:
+    def executors(self) -> Dict[Tuple[str, str], Executor]:
         return self._gretel_executors | self._custom_executors
 
     def _make_project(self) -> Project:
@@ -111,22 +133,23 @@ class Comparison:
 
         _trainer_project_index = 0
         for dataset in self.datasets:
-            artifact_key = _upload_dataset_to_project(
-                dataset.data_source, self._project, self.config.trainer
-            )
-            for model in self.gretel_models:
-                self._setup_gretel_run(
-                    dataset, model, artifact_key, _trainer_project_index
-                )
-                _trainer_project_index += 1
+            if self.gretel_models:
+                artifact_key = _upload_dataset_to_project(
+                    dataset.data_source, self._project, self.config.trainer
+                ) if not dataset.public else None
+                for model in self.gretel_models:
+                    self._setup_gretel_run(
+                        dataset, model, artifact_key, _trainer_project_index
+                    )
+                    _trainer_project_index += 1
             for model in self.custom_models:
                 self._setup_custom_run(dataset, model)
 
         return self
 
     def execute(self) -> Comparison:
-        for run_identifier, executor in self._gretel_executors.items():
-            self.futures[run_identifier] = self.thread_pool.submit(
+        for run_key, executor in self._gretel_executors.items():
+            self.futures[run_key] = self.thread_pool.submit(
                 _run_gretel, executor
             )
 
@@ -139,7 +162,7 @@ class Comparison:
 
     @property
     def results(self) -> pd.DataFrame:
-        result_records = [self._result_dict(run_id) for run_id in self.executors]
+        result_records = [self._result_dict(run_key) for run_key in self.executors]
         return pd.DataFrame.from_records(result_records)
 
     def export_results(self, destination: str) -> None:
@@ -163,8 +186,8 @@ class Comparison:
         return job.logs
 
     def _get_gretel_job(self, model: str, dataset: str, action: str) -> Job:
-        run_id = f"{model}-{dataset}"
-        executor = self.executors[run_id]
+        run_key = (model, dataset)
+        executor = self.executors[run_key]
         strategy = executor.strategy
         if not isinstance(strategy, GretelSDKStrategy):
             raise BenchmarkException("Cannot get Gretel job for non-GretelSDK runs")
@@ -190,9 +213,9 @@ class Comparison:
             for project in search_projects(query=self.config.project_display_name):
                 project.delete()
 
-    def _result_dict(self, run_identifier: str) -> Dict[str, Any]:
-        executor = self.executors[run_identifier]
-        model_name, dataset_name = run_identifier.split(RUN_IDENTIFIER_SEPARATOR, 1)
+    def _result_dict(self, run_key: Tuple[str, str]) -> Dict[str, Any]:
+        executor = self.executors[run_key]
+        model_name, dataset_name = run_key
 
         train_time = executor.strategy.get_train_time()
         generate_time = executor.strategy.get_generate_time()
@@ -209,6 +232,10 @@ class Comparison:
             "Columns": executor.strategy.dataset.column_count,
             "Status": executor.status.value,
             "SQS": executor.get_sqs_score(),
+            **{
+                score_name: executor.get_report_score(score_key)
+                for score_name, score_key in self._extra_report_scores.items()
+            },
             "Train time (sec)": train_time,
             "Generate time (sec)": generate_time,
             "Total time (sec)": total_time,
@@ -221,7 +248,8 @@ class Comparison:
         artifact_key: Optional[str],
         trainer_project_index: int,
     ) -> None:
-        run_identifier = _make_run_identifier(model, dataset)
+        run_key = _make_run_key(model, dataset)
+        run_identifier = _make_run_identifier(run_key)
         strategy = self._set_gretel_strategy(
             benchmark_model=model,
             dataset=dataset,
@@ -235,14 +263,15 @@ class Comparison:
             evaluate_project=self._project,
             config=self.config,
         )
-        self._gretel_executors[run_identifier] = executor
+        self._gretel_executors[run_key] = executor
 
     def _setup_custom_run(
         self,
         dataset: Dataset,
         model: CustomModel,
     ) -> None:
-        run_identifier = _make_run_identifier(model, dataset)
+        run_key = _make_run_key(model, dataset)
+        run_identifier = _make_run_identifier(run_key)
         strategy = CustomStrategy(
             benchmark_model=model,
             dataset=dataset,
@@ -255,7 +284,7 @@ class Comparison:
             evaluate_project=self._project,
             config=self.config,
         )
-        self._custom_executors[run_identifier] = executor
+        self._custom_executors[run_key] = executor
 
     def _basic_status(self, future: Future) -> str:
         if future.done():
@@ -318,15 +347,18 @@ def _make_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
         row_count=dataset.row_count,
         column_count=dataset.column_count,
         data_source=source,
+        public=dataset.public,
     )
 
 
-def _make_run_identifier(
-    model: Union[GretelModel, CustomModel], dataset: Dataset
-) -> str:
-    run_identifier = f"{_model_name(model)}{RUN_IDENTIFIER_SEPARATOR}{dataset.name}"
-    log(run_identifier, "preparing run")
-    return run_identifier
+def _make_run_key(model: Union[GretelModel, CustomModel], dataset: Dataset) -> Tuple[str, str]:
+    run_key = (_model_name(model), dataset.name)
+    return run_key
+
+
+def _make_run_identifier(run_key: Tuple[str, str]) -> str:
+    model_name, dataset_name = run_key
+    return RUN_IDENTIFIER_SEPARATOR.join((model_name, dataset_name))
 
 
 def _validate_setup(

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -162,12 +162,11 @@ class Comparison:
 
         _trainer_project_index = 0
         for dataset in self.datasets:
-            artifact_key = (
-                _upload_dataset_to_project(
-                    dataset.data_source, self._project, self.config.trainer
-                )
-                if not dataset.public
-                else None
+            # TODO: avoid upload for public datasets, when possible
+            artifact_key = _upload_dataset_to_project(
+                dataset.data_source,
+                self._project,
+                self.config.trainer,
             )
 
             for model in self.gretel_models:

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Tuple, Type, Union
@@ -29,7 +29,7 @@ class Dataset:
     data_source: str
     row_count: int
     column_count: int
-
+    public: bool = field(default=False)
 
 @dataclass
 class BenchmarkConfig:

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -31,6 +31,7 @@ class Dataset:
     column_count: int
     public: bool = field(default=False)
 
+
 @dataclass
 class BenchmarkConfig:
     project_display_name: str

--- a/src/gretel_trainer/benchmark/custom/datasets.py
+++ b/src/gretel_trainer/benchmark/custom/datasets.py
@@ -16,7 +16,6 @@ class CustomDataset:
     row_count: int = field(init=False, repr=False)
     column_count: int = field(init=False, repr=False)
     delimiter: str
-    public: bool = field(repr=False, default=False)
 
     def __post_init__(self):
         if isinstance(self.data_source, str):
@@ -25,8 +24,10 @@ class CustomDataset:
             rows, cols = self.data_source.shape
         self.row_count = rows
         self.column_count = cols
-        if self.public and not isinstance(self.data_source, str):
-            raise ValueError("datasets specified as dataframes can't be public")
+
+    @property
+    def public(self) -> bool:
+        return False  # custom datasets can't be public, currently
 
 
 def _to_datatype(d: Union[str, Datatype]) -> Datatype:

--- a/src/gretel_trainer/benchmark/custom/datasets.py
+++ b/src/gretel_trainer/benchmark/custom/datasets.py
@@ -16,6 +16,7 @@ class CustomDataset:
     row_count: int = field(init=False, repr=False)
     column_count: int = field(init=False, repr=False)
     delimiter: str
+    public: bool = field(repr=False, default=False)
 
     def __post_init__(self):
         if isinstance(self.data_source, str):
@@ -24,6 +25,8 @@ class CustomDataset:
             rows, cols = self.data_source.shape
         self.row_count = rows
         self.column_count = cols
+        if self.public and not isinstance(self.data_source, str):
+            raise ValueError("datasets specified as dataframes can't be public")
 
 
 def _to_datatype(d: Union[str, Datatype]) -> Datatype:

--- a/src/gretel_trainer/benchmark/custom/strategy.py
+++ b/src/gretel_trainer/benchmark/custom/strategy.py
@@ -14,11 +14,13 @@ class CustomStrategy:
         dataset: Dataset,
         run_identifier: str,
         config: BenchmarkConfig,
+        artifact_key: Optional[str] = None,
     ):
         self.benchmark_model = benchmark_model
         self.dataset = dataset
         self.run_identifier = run_identifier
         self.config = config
+        self.artifact_key = artifact_key
 
         self.train_timer: Optional[Timer] = None
         self.generate_timer: Optional[Timer] = None
@@ -38,6 +40,8 @@ class CustomStrategy:
 
     @property
     def evaluate_ref_data(self) -> str:
+        if self.artifact_key is not None:
+            return self.artifact_key
         return self.dataset.data_source
 
     @property

--- a/src/gretel_trainer/benchmark/executor.py
+++ b/src/gretel_trainer/benchmark/executor.py
@@ -87,12 +87,6 @@ class Executor:
         if self.status.can_proceed:
             self._evaluate()
 
-    def get_sqs_score(self) -> Optional[int]:
-        if self.evaluate_report_json is None:
-            return None
-        else:
-            return self.evaluate_report_json["synthetic_data_quality_score"]["score"]
-
     def get_report_score(self, key: str) -> Optional[int]:
         if self.evaluate_report_json is None:
             return None

--- a/src/gretel_trainer/benchmark/executor.py
+++ b/src/gretel_trainer/benchmark/executor.py
@@ -93,6 +93,11 @@ class Executor:
         else:
             return self.evaluate_report_json["synthetic_data_quality_score"]["score"]
 
+    def get_report_score(self, key: str) -> Optional[int]:
+        if self.evaluate_report_json is None:
+            return None
+        return self.evaluate_report_json[key]["score"]
+
     def _maybe_skip(self) -> None:
         if not self.strategy.runnable():
             self._log("skipping")
@@ -124,13 +129,15 @@ class Executor:
         self._log("starting evaluation")
         self.status = Status.Evaluating
 
-        self.evaluate_model = create_evaluate_model(
-            project=self.evaluate_project,
-            data_source=str(run_out_path(self.config.working_dir, self.run_identifier)),
-            ref_data=self.strategy.evaluate_ref_data,
-            run_identifier=self.run_identifier,
-        )
+        records_file = str(run_out_path(self.config.working_dir, self.run_identifier))
+        records_artifact_key = self.evaluate_project.upload_artifact(records_file)
         try:
+            self.evaluate_model = create_evaluate_model(
+                project=self.evaluate_project,
+                data_source=records_artifact_key,
+                ref_data=self.strategy.evaluate_ref_data,
+                run_identifier=self.run_identifier,
+            )
             self.evaluate_report_json = run_evaluate(
                 evaluate_model=self.evaluate_model,
                 run_identifier=self.run_identifier,
@@ -142,6 +149,11 @@ class Executor:
             self._log("evaluation failed")
             self.status = Status.FailedEvaluate
             self.exception = e
+        finally:
+            try:
+                self.evaluate_project.delete_artifact(records_artifact_key)
+            except:
+                pass
 
     def _log(self, msg: str) -> None:
         log(self.run_identifier, msg)

--- a/src/gretel_trainer/benchmark/gretel/datasets.py
+++ b/src/gretel_trainer/benchmark/gretel/datasets.py
@@ -37,6 +37,10 @@ class GretelDataset:
     def __repr__(self) -> str:
         return f"GretelDataset(name={self.name}, datatype={self.datatype})"
 
+    @property
+    def public(self) -> bool:
+        return True
+
 
 class GretelDatasetRepo:
     def __init__(self):

--- a/src/gretel_trainer/benchmark/gretel/models.py
+++ b/src/gretel_trainer/benchmark/gretel/models.py
@@ -1,5 +1,7 @@
+import copy
+from inspect import isclass
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Type, Union
 
 from gretel_client.projects.exceptions import ModelConfigError
 from gretel_client.projects.models import read_model_config
@@ -83,3 +85,87 @@ class GretelGPTX(GretelModel):
 
 class GretelDGAN(GretelModel):
     config = "synthetics/time-series"
+
+
+class _GretelModelWithOverrides(GretelModel):
+
+    _delegate: GretelModel
+    _name: str
+    _extra_config: Optional[dict]
+
+    def __init__(self,
+                 delegate: GretelModel,
+                 name: str = "",
+                 extra_config: Optional[dict] = None,
+    ):
+        self._delegate = delegate
+        self._name = name
+        self._extra_config = extra_config
+
+    @property
+    def name(self) -> str:
+        return self._name if self._name else self._delegate.name
+
+    @property
+    def config(self) -> GretelModelConfig:
+        if not self._extra_config:
+            return self._delegate.config
+
+        cfg = copy.deepcopy(read_model_config(self._delegate.config))
+        model_cfg = next(c for c in cfg["models"][0].values())
+        _recursive_dict_update(model_cfg, self._extra_config)
+        return cfg
+
+    @property
+    def model_key(self) -> str:
+        return self._delegate.model_key
+
+    @property
+    def trainer_model_type(self) -> Optional[gretel_trainer.models._BaseConfig]:
+        return self._delegate.trainer_model_type
+
+    def runnable(self, dataset: Dataset) -> bool:
+        return self._delegate.runnable(dataset)
+
+
+def configure_model(
+        model: Union[Type[GretelModel], GretelModel],
+        name: str = "",
+        extra_config: Optional[dict] = None,
+) -> GretelModel:
+    """Returns a GretelModel with an updated model configuration and/or name.
+
+    This function works both on a GretelModel subclass as well as on a GretelModel
+    instance. The result is always a GretelModel instance.
+
+    The returned GretelModel differs from the input in only two aspects:
+    - the name is possibly changed, and
+    - the model config has been overridden according to `config_override`.
+
+    Args:
+        model:
+            Model class or instance to modify.
+        name:
+            A custom name for the model.
+        config_override:
+            A dict that is applied as an override to the model config.
+
+    Returns:
+        A GretelModel instance..
+    """
+    if isclass(model):
+        model = model()
+
+    return _GretelModelWithOverrides(delegate=model, name=name, extra_config=extra_config)
+
+
+def _recursive_dict_update(a: dict, b: dict, _ctx: str = "") -> dict:
+    for k, vb in b.items():
+        if not isinstance(va := a.get(k, None), dict):
+            # Overwrite non-dict entries
+            a[k] = vb
+        elif not isinstance(vb, dict):
+            raise ValueError(f"cannot merge non-dict value into dict at key {_ctx}{k}")
+        else:
+            _recursive_dict_update(va, vb, _ctx=f"{_ctx}{k}.")
+    return a

--- a/src/gretel_trainer/benchmark/gretel/models.py
+++ b/src/gretel_trainer/benchmark/gretel/models.py
@@ -1,7 +1,7 @@
 import copy
 from inspect import isclass
 from pathlib import Path
-from typing import Dict, Optional, Type, Union
+from typing import cast, Dict, Optional, Type, Union
 
 from gretel_client.projects.exceptions import ModelConfigError
 from gretel_client.projects.models import read_model_config
@@ -153,10 +153,13 @@ def configure_model(
     Returns:
         A GretelModel instance..
     """
-    if isclass(model):
-        model = model()
+    model_instance = cast(GretelModel, model() if isclass(model) else model)
 
-    return _GretelModelWithOverrides(delegate=model, name=name, extra_config=extra_config)
+    return _GretelModelWithOverrides(
+        delegate=model_instance,
+        name=name,
+        extra_config=extra_config,
+    )
 
 
 def _recursive_dict_update(a: dict, b: dict, _ctx: str = "") -> dict:

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import requests
-from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status
+from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status, RunnerMode
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.projects import Project
 from gretel_client.projects.records import RecordHandler
@@ -61,7 +61,9 @@ class GretelSDKStrategy:
         self.model = self.project.create_model_obj(
             model_config=model_config, data_source=data_source
         )
-        self.model.submit_cloud()
+        # Calling this in lieu of submit_cloud() is supposed to avoid
+        # artifact upload. Doesn't work for more recent client versions!
+        self.model.submit(runner_mode=RunnerMode.CLOUD)
         job_status = self._await_job(self.model, "training")
         if job_status in END_STATES and job_status != Status.COMPLETED:
             raise BenchmarkException("Training failed")

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import requests
-from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status, RunnerMode
+from gretel_client.projects.jobs import (
+    ACTIVE_STATES,
+    END_STATES,
+    Job,
+    RunnerMode,
+    Status,
+)
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.projects import Project
 from gretel_client.projects.records import RecordHandler
@@ -95,10 +101,11 @@ class GretelSDKStrategy:
 
     @property
     def evaluate_ref_data(self) -> str:
-        if self.model is None:
-            return self.dataset.data_source
-        else:
+        if self.artifact_key is not None:
+            return self.artifact_key
+        if self.model is not None:
             return self.model.data_source
+        return self.dataset.data_source
 
     @property
     def _synthetic_data_path(self) -> Path:

--- a/src/gretel_trainer/benchmark/sdk_extras.py
+++ b/src/gretel_trainer/benchmark/sdk_extras.py
@@ -3,7 +3,13 @@ import time
 from typing import Any, Dict, Tuple
 
 import smart_open
-from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status, RunnerMode
+from gretel_client.projects.jobs import (
+    ACTIVE_STATES,
+    END_STATES,
+    Job,
+    RunnerMode,
+    Status,
+)
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.projects import Project
 

--- a/src/gretel_trainer/benchmark/sdk_extras.py
+++ b/src/gretel_trainer/benchmark/sdk_extras.py
@@ -3,7 +3,7 @@ import time
 from typing import Any, Dict, Tuple
 
 import smart_open
-from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status
+from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Job, Status, RunnerMode
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.projects import Project
 
@@ -28,7 +28,9 @@ def run_evaluate(
     run_identifier: str,
     wait: int,
 ) -> Dict[str, Any]:
-    evaluate_model.submit_cloud()
+    # Calling this in lieu of submit_cloud() is supposed to avoid
+    # artifact upload. Doesn't work for more recent client versions!
+    evaluate_model.submit(runner_mode=RunnerMode.CLOUD)
     job_status = await_job(run_identifier, evaluate_model, "evaluation", wait)
     if job_status in END_STATES and job_status != Status.COMPLETED:
         raise BenchmarkException("Evaluate failed")

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -175,7 +175,6 @@ def test_run_happy_path_gretel_sdk(
     result = comparison.results.iloc[0]
     model_name = benchmark_model.__name__
     assert result["Model"] == model_name
-    print(comparison.executors[(model_name, "iris")].exception)
     assert result["Status"] == "Complete"
     assert result["SQS"] == 95
     assert result["Train time (sec)"] == 30

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -16,7 +16,6 @@ from gretel_trainer.benchmark import (
     compare,
     make_dataset,
 )
-from gretel_trainer.benchmark.core import BenchmarkException
 from tests.benchmark.mocks import (
     DoNothingModel,
     FailsToGenerate,
@@ -176,7 +175,7 @@ def test_run_happy_path_gretel_sdk(
     result = comparison.results.iloc[0]
     model_name = benchmark_model.__name__
     assert result["Model"] == model_name
-    print(comparison.executors[f"{model_name}-iris"].exception)
+    print(comparison.executors[(model_name, "iris")].exception)
     assert result["Status"] == "Complete"
     assert result["SQS"] == 95
     assert result["Train time (sec)"] == 30


### PR DESCRIPTION
This PR modifies b2 in a few ways I have found convenient:
- Support for quality scores other than SQS in the comparison table, via the `additional_report_scores` param (e.g., `additional_report_scores=["FCS", "PCS", "FDS"]`)
- Key runs by `(model, dataset)` pairs instead of `{model}-{dataset}` string. The latter can not be parsed unambiguously if the model or dataset names contain a dash.
- Support for marking datasets as public to avoid uploading them (note: this no longer works in most recent Python client release, though)
- Support instances in the `models` list instead of just classes (classes still work). This mostly enables the next item:
- Adds a `configure_model` function, that allows overriding the name and/or config of a model.