### PR TITLE
Seed fix

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union, overload
 
 import networkx
 import pandas as pd
-from networkx.algorithms.dag import dag_longest_path_length
+from networkx.algorithms.dag import dag_longest_path_length, topological_sort
 from pandas.api.types import is_string_dtype
 from typing_extensions import Literal
 
@@ -330,6 +330,15 @@ class RelationalData:
         _add_children(descendants, table)
 
         return list(descendants)
+
+    def list_tables_parents_before_children(self) -> List[str]:
+        """
+        Returns a list of all tables with the guarantee that a parent table
+        appears before any of its children. No other guarantees about order
+        are made, e.g. the following (and others) are all valid outputs:
+        [p1, p2, c1, c2] or [p2, c2, p1, c1] or [p2, p1, c1, c2] etc.
+        """
+        return list(reversed(list(topological_sort(self.graph))))
 
     def get_primary_key(self, table: str) -> List[str]:
         return self.graph.nodes[table]["primary_key"]

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -334,8 +334,11 @@ class RelationalData:
     def get_primary_key(self, table: str) -> List[str]:
         return self.graph.nodes[table]["primary_key"]
 
-    def get_table_data(self, table: str) -> pd.DataFrame:
-        return self.graph.nodes[table]["data"]
+    def get_table_data(
+        self, table: str, usecols: Optional[set[str]] = None
+    ) -> pd.DataFrame:
+        usecols = usecols or self.get_table_columns(table)
+        return self.graph.nodes[table]["data"][list(usecols)]
 
     def get_table_columns(self, table: str) -> set[str]:
         return self.graph.nodes[table]["columns"]

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Union, overload
 import networkx
 import pandas as pd
 from networkx.algorithms.dag import dag_longest_path_length
+from pandas.api.types import is_string_dtype
 from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,24 @@ class RelationalData:
             data=data,
             columns=set(data.columns),
         )
+        self._set_safe_ancestral_seed_columns(name)
+
+    def _set_safe_ancestral_seed_columns(self, table: str) -> None:
+        cols = set()
+
+        # Key columns are always kept
+        cols.update(self.get_primary_key(table))
+        for fk in self.get_foreign_keys(table):
+            cols.update(fk.columns)
+
+        data = self.get_table_data(table)
+        for col in self.get_table_columns(table):
+            if col in cols:
+                continue
+            if _ok_for_train_and_seed(col, data):
+                cols.add(col)
+
+        self.graph.nodes[table]["safe_ancestral_seed_columns"] = cols
 
     def set_primary_key(
         self, *, table: str, primary_key: UserFriendlyPrimaryKeyT
@@ -170,6 +189,7 @@ class RelationalData:
                 raise MultiTableException(f"Unrecognized column name: `{primary_key}`")
 
         self.graph.nodes[table]["primary_key"] = primary_key
+        self._set_safe_ancestral_seed_columns(table)
 
     def _format_key_column(self, key: Optional[Union[str, List[str]]]) -> List[str]:
         if key is None:
@@ -241,6 +261,7 @@ class RelationalData:
             )
         )
         edge["via"] = via
+        self._set_safe_ancestral_seed_columns(table)
 
     def remove_foreign_key(self, table: str, constrained_columns: List[str]) -> None:
         """
@@ -266,11 +287,13 @@ class RelationalData:
             self.graph.remove_edge(table, key_to_remove.parent_table_name)
         else:
             edge["via"] = via
+        self._set_safe_ancestral_seed_columns(table)
 
     def update_table_data(self, table: str, data: pd.DataFrame) -> None:
         try:
             self.graph.nodes[table]["data"] = data
             self.graph.nodes[table]["columns"] = data.columns
+            self._set_safe_ancestral_seed_columns(table)
         except KeyError:
             raise MultiTableException(
                 f"Unrecognized table name: {table}. If this is a new table to add, use `add_table`."
@@ -316,6 +339,9 @@ class RelationalData:
 
     def get_table_columns(self, table: str) -> set[str]:
         return self.graph.nodes[table]["columns"]
+
+    def get_safe_ancestral_seed_columns(self, table: str) -> set[str]:
+        return self.graph.nodes[table]["safe_ancestral_seed_columns"]
 
     def get_foreign_keys(self, table: str) -> List[ForeignKey]:
         foreign_keys = []
@@ -412,3 +438,38 @@ class RelationalData:
             )
 
         return relational_data
+
+
+def _ok_for_train_and_seed(col: str, df: pd.DataFrame) -> bool:
+    if _is_highly_nan(col, df):
+        return False
+
+    if _is_highly_unique_categorical(col, df):
+        return False
+
+    return True
+
+
+def _is_highly_nan(col: str, df: pd.DataFrame) -> bool:
+    total = len(df)
+    if total == 0:
+        return False
+
+    missing = df[col].isnull().sum()
+    missing_perc = missing / total
+    return missing_perc > 0.2
+
+
+def _is_highly_unique_categorical(col: str, df: pd.DataFrame) -> bool:
+    return is_string_dtype(df[col]) and _percent_unique(col, df) >= 0.7
+
+
+def _percent_unique(col: str, df: pd.DataFrame) -> float:
+    col_no_nan = df[col].dropna()
+    total = len(col_no_nan)
+    distinct = col_no_nan.nunique()
+
+    if total == 0:
+        return 0.0
+    else:
+        return distinct / total

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -54,7 +54,11 @@ def label_encode_keys(
     Crawls tables for all key columns (primary and foreign). For each PK (and FK columns referencing it),
     runs all values through a LabelEncoder and updates tables' columns to use LE-transformed values.
     """
-    for table_name, df in tables.items():
+    for table_name in rel_data.list_tables_parents_before_children():
+        df = tables.get(table_name)
+        if df is None:
+            continue
+
         for primary_key_column in rel_data.get_primary_key(table_name):
 
             # Get a set of the tables and columns in `tables` referencing this PK

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -155,9 +155,7 @@ def test_prepare_training_data_with_composite_keys(tpch):
         "self|ps_suppkey",
         "self|ps_availqty",
         "self.ps_partkey|p_partkey",
-        "self.ps_partkey|p_name",
         "self.ps_suppkey|s_suppkey",
-        "self.ps_suppkey|s_name",
     }
     assert len(train_partsupp) == len(tpch.get_table_data("partsupp")) + 3
     last_three_partsupp_keys = train_partsupp.tail(3).reset_index()[
@@ -183,9 +181,7 @@ def test_prepare_training_data_with_composite_keys(tpch):
         "self.l_partkey+l_suppkey|ps_suppkey",
         "self.l_partkey+l_suppkey|ps_availqty",
         "self.l_partkey+l_suppkey.ps_partkey|p_partkey",
-        "self.l_partkey+l_suppkey.ps_partkey|p_name",
         "self.l_partkey+l_suppkey.ps_suppkey|s_suppkey",
-        "self.l_partkey+l_suppkey.ps_suppkey|s_name",
     }
     assert len(train_lineitem) == len(tpch.get_table_data("lineitem")) + 3
     last_three_lineitem_keys = train_lineitem.tail(3).reset_index()[

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -185,6 +185,19 @@ def test_get_subset_of_data(pets):
     assert len(subset) == normal_length
 
 
+def test_list_tables_parents_before_children(ecom):
+    def in_order(col, t1, t2):
+        return col.index(t1) < col.index(t2)
+
+    tables = ecom.list_tables_parents_before_children()
+    assert in_order(tables, "users", "events")
+    assert in_order(tables, "distribution_center", "products")
+    assert in_order(tables, "distribution_center", "inventory_items")
+    assert in_order(tables, "products", "inventory_items")
+    assert in_order(tables, "inventory_items", "order_items")
+    assert in_order(tables, "users", "order_items")
+
+
 def test_relational_data_as_dict(ecom):
     as_dict = ecom.as_dict("test_out")
 

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -178,6 +178,13 @@ def test_set_primary_key(ecom):
         ecom.set_primary_key(table="users", primary_key="not_a_column")
 
 
+def test_get_subset_of_data(pets):
+    normal_length = len(pets.get_table_data("humans"))
+    subset = pets.get_table_data("humans", ["name", "city"])
+    assert set(subset.columns) == {"name", "city"}
+    assert len(subset) == normal_length
+
+
 def test_relational_data_as_dict(ecom):
     as_dict = ecom.as_dict("test_out")
 

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -85,7 +85,7 @@ def test_column_metadata(pets):
     )
     assert pets.get_safe_ancestral_seed_columns("humans") == {"id", "name", "city"}
 
-    # Setting a column as a foreign key ensures it is included
+    # Removing a foreign key refreshes the cache state
     pets.remove_foreign_key("humans", ["city"])
     assert pets.get_safe_ancestral_seed_columns("humans") == {"id", "name"}
 


### PR DESCRIPTION
Fixes two bugs.

1. When using Ancestral strategy, we were previously basing the "highly NaN" and "highly unique categorical" calculations (to determine whether or not we include them in training and seeding) on the column data as it appeared in the joined ancestral, not the source parent table. A column could be highly unique in the source (e.g. team name in the NBA database `Teams` table), but as a result of the particular foreign key frequency on some child table it is possible to _not_ hit the uniqueness threshold when appearing as a joined ancestral column. This led to a bug where we would train on that data and attempt to use it as a seed column, but the synthetic child data used as a seed would include categorical values not seen during training, ultimately resulting in having to throw away records as invalid conditional seeds.
2. When label encoding keys on tables, we were previously iterating through the tables in an arbitrary order. This led to a bug (possibly limited to composite keys): a child table with a composite PK made up of two individual FK columns could be label-encoded "in isolation" before the parent table is label-encoded, and as a result we lost referential integrity between the two. We now ensure that tables are label-encoded in proper order, i.e. parents before children.

### Implementation note

The logic for determining if a column is highly NaN or highly unique categorical now exists in the `RelationalData` class itself, rather than being owned by the `AncestralStrategy`. One immediate benefit is we now perform the calculation just once for each table and cache the result, rather than recalculate it every time the table is joined onto a child table. Additionally, in the future there _might_ be ways for us to get this metadata from a more sophisticated connector... **if** that is possible, the result would need to live in `RelationalData` anyways, so making this change now sets us up better for that possibility.