### PR TITLE
Classify

### DIFF
--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -249,6 +249,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Classify\n",
+    "\n",
+    "Run Gretel Classify on all tables to identify PII.\n",
+    "\n",
+    "By default, Relational Classify will provide results for the first 100 rows in each table. To process the entire table, set `all_rows=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "config_yaml = \"\"\"\n",
+    "schema_version: \"1.0\"\n",
+    "name: \"classify-default\"\n",
+    "models:\n",
+    "  - classify:\n",
+    "      data_source: \"_\"\n",
+    "      labels:\n",
+    "        - person_name\n",
+    "        - credit_card_number\n",
+    "        - phone_number\n",
+    "        - us_social_security_number\n",
+    "        - email_address\n",
+    "        - location\n",
+    "        - acme/*\n",
+    "        \n",
+    "label_predictors:\n",
+    "  namespace: acme\n",
+    "  regex:\n",
+    "    user_id:\n",
+    "      patterns:\n",
+    "        - score: high\n",
+    "          regex: ^user_[\\d]{5}$\n",
+    "\"\"\"\n",
+    "config = yaml.safe_load(config_yaml)\n",
+    "\n",
+    "multitable.classify(config)\n",
+    "\n",
+    "# Run classify on all rows\n",
+    "# multitable.classify(config, all_rows=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Transforms\n",
     "\n",
     "Train Gretel Transforms models by providing table-specific model configs. You only need to train models for tables you want to transform—you do not need to supply a config for every table."

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -14,6 +14,7 @@ class ArtifactCollection:
     hybrid: bool
     gretel_debug_summary: Optional[str] = None
     source_archive: Optional[str] = None
+    classify_outputs_archive: Optional[str] = None
     synthetics_training_archive: Optional[str] = None
     synthetics_outputs_archive: Optional[str] = None
     transforms_outputs_archive: Optional[str] = None
@@ -25,6 +26,10 @@ class ArtifactCollection:
     def upload_source_archive(self, project: Project, path: str) -> None:
         existing = self.source_archive
         self.source_archive = self._upload_file(project, path, existing)
+
+    def upload_classify_outputs_archive(self, project: Project, path: str) -> None:
+        existing = self.classify_outputs_archive
+        self.classify_outputs_archive = self._upload_file(project, path, existing)
 
     def upload_synthetics_training_archive(self, project: Project, path: str) -> None:
         existing = self.synthetics_training_archive

--- a/src/gretel_trainer/relational/artifacts.py
+++ b/src/gretel_trainer/relational/artifacts.py
@@ -71,7 +71,7 @@ def add_to_tar(targz: Path, src: Path, arcname: str) -> None:
 
                 r.extractall(tmpdir)
                 for member in r.getnames():
-                    if os.path.isfile(tmpdir / member):
+                    if os.path.isfile(tmpdir / member) and not member == arcname:
                         w.add(tmpdir / member, arcname=member)
     else:
         with tarfile.open(targz, "w:gz") as tar:

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -52,6 +52,11 @@ class BackupRelationalData:
 
 
 @dataclass
+class BackupClassify:
+    model_ids: Dict[str, str]
+
+
+@dataclass
 class BackupTransformsTrain:
     model_ids: Dict[str, str]
     lost_contact: List[str]
@@ -83,6 +88,7 @@ class Backup:
     refresh_interval: int
     artifact_collection: ArtifactCollection
     relational_data: BackupRelationalData
+    classify: Optional[BackupClassify] = None
     transforms_train: Optional[BackupTransformsTrain] = None
     synthetics_train: Optional[BackupSyntheticsTrain] = None
     generate: Optional[BackupGenerate] = None
@@ -119,6 +125,10 @@ class Backup:
             artifact_collection=ArtifactCollection(**b["artifact_collection"]),
             relational_data=brd,
         )
+
+        classify = b.get("classify")
+        if classify is not None:
+            backup.classify = BackupClassify(**classify)
 
         transforms_train = b.get("transforms_train")
         if transforms_train is not None:

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Any, Dict, List
 
 from gretel_client.projects.models import read_model_config
@@ -9,19 +10,23 @@ from gretel_trainer.relational.core import (
 )
 
 
+def _ingest(config: GretelModelConfig) -> Dict[str, Any]:
+    return read_model_config(deepcopy(config))
+
+
 def _model_name(workflow: str, table: str) -> str:
     ok_table_name = table.replace("--", "__")
     return f"{workflow}-{ok_table_name}"
 
 
 def make_evaluate_config(table: str) -> Dict[str, Any]:
-    tailored_config = read_model_config("evaluate/default")
+    tailored_config = _ingest("evaluate/default")
     tailored_config["name"] = _model_name("evaluate", table)
     return tailored_config
 
 
 def make_synthetics_config(table: str, config: GretelModelConfig) -> Dict[str, Any]:
-    tailored_config = read_model_config(config)
+    tailored_config = _ingest(config)
     tailored_config["name"] = _model_name("synthetics", table)
     return tailored_config
 
@@ -29,7 +34,7 @@ def make_synthetics_config(table: str, config: GretelModelConfig) -> Dict[str, A
 def make_transform_config(
     rel_data: RelationalData, table: str, config: GretelModelConfig
 ) -> Dict[str, Any]:
-    tailored_config = read_model_config(config)
+    tailored_config = _ingest(config)
     tailored_config["name"] = _model_name("transforms", table)
 
     key_columns = rel_data.get_all_key_columns(table)

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -19,6 +19,12 @@ def _model_name(workflow: str, table: str) -> str:
     return f"{workflow}-{ok_table_name}"
 
 
+def make_classify_config(table: str, config: GretelModelConfig) -> Dict[str, Any]:
+    tailored_config = _ingest(config)
+    tailored_config["name"] = _model_name("classify", table)
+    return tailored_config
+
+
 def make_evaluate_config(table: str) -> Dict[str, Any]:
     tailored_config = _ingest("evaluate/default")
     tailored_config["name"] = _model_name("evaluate", table)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -54,6 +54,7 @@ from gretel_trainer.relational.tasks import (
     TransformsTrainTask,
 )
 from gretel_trainer.relational.workflow_state import (
+    Classify,
     SyntheticsRun,
     SyntheticsTrain,
     TransformsTrain,
@@ -94,6 +95,7 @@ class MultiTable:
         self._artifact_collection = ArtifactCollection(hybrid=self._hybrid)
         self._extended_sdk = ExtendedGretelSDK(hybrid=self._hybrid)
         self._latest_backup: Optional[Backup] = None
+        self._classify = Classify()
         self._transforms_train = TransformsTrain()
         self.transform_output_tables: Dict[str, pd.DataFrame] = {}
         self._synthetics_train = SyntheticsTrain()
@@ -460,27 +462,34 @@ class MultiTable:
         )
 
     def classify(self, config: GretelModelConfig, all_rows: bool = False) -> None:
-        classify_models = {}
+        classify_data_sources = {}
         for table in self.relational_data.list_all_tables():
+
             classify_config = make_classify_config(table, config)
 
             # Ensure consistent, friendly data source names in Console
             table_data = self.relational_data.get_table_data(table)
-            classify_data_source_path = (
+            classify_data_source_path = str(
                 self._working_dir / f"classify_data_source_{table}.csv"
             )
             table_data.to_csv(classify_data_source_path, index=False)
 
-            # Create model
+            classify_data_sources[table] = classify_data_source_path
+
+            # Create model if necessary
+            if self._classify.models.get(table) is not None:
+                continue
+
             model = self._project.create_model_obj(
-                model_config=classify_config, data_source=str(classify_data_source_path)
+                model_config=classify_config, data_source=classify_data_source_path
             )
-            classify_models[table] = model
+            self._classify.models[table] = model
 
         self._backup()
 
         task = ClassifyTask(
-            classify_models=classify_models,
+            classify=self._classify,
+            data_sources=classify_data_sources,
             all_rows=all_rows,
             multitable=self,
             out_dir=self._working_dir,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -487,7 +487,6 @@ class MultiTable:
     def classify(self, config: GretelModelConfig, all_rows: bool = False) -> None:
         classify_data_sources = {}
         for table in self.relational_data.list_all_tables():
-
             classify_config = make_classify_config(table, config)
 
             # Ensure consistent, friendly data source names in Console

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -163,6 +163,20 @@ class MultiTable:
                 self._working_dir / "_gretel_debug_summary.json",
             )
 
+        # Classify
+        classify_outputs_archive_path = (
+            self._working_dir / "classify_outputs.tar.gz"
+        )
+        if (classify_outputs_archive_id := backup.artifact_collection.classify_outputs_archive) is not None:
+            self._extended_sdk.download_tar_artifact(
+                self._project,
+                classify_outputs_archive_id,
+                classify_outputs_archive_path,
+            )
+        if classify_outputs_archive_path.exists():
+            with tarfile.open(classify_outputs_archive_path, "r:gz") as tar:
+                tar.extractall(path=self._working_dir)
+
         # Transforms Train
         backup_transforms_train = backup.transforms_train
         if backup_transforms_train is None:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -475,8 +475,8 @@ class MultiTable:
         run_task(task, self._extended_sdk)
 
         archive_path = self._working_dir / "classify_outputs.tar.gz"
-        for table, result in task.result_filepaths.items():
-            add_to_tar(archive_path, result, f"classify_{table}.gz")
+        for arcname, path in task.result_filepaths.items():
+            add_to_tar(archive_path, path, arcname)
         self._artifact_collection.upload_classify_outputs_archive(
             self._project, str(archive_path)
         )

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -164,10 +164,10 @@ class MultiTable:
             )
 
         # Classify
-        classify_outputs_archive_path = (
-            self._working_dir / "classify_outputs.tar.gz"
-        )
-        if (classify_outputs_archive_id := backup.artifact_collection.classify_outputs_archive) is not None:
+        classify_outputs_archive_path = self._working_dir / "classify_outputs.tar.gz"
+        if (
+            classify_outputs_archive_id := backup.artifact_collection.classify_outputs_archive
+        ) is not None:
             self._extended_sdk.download_tar_artifact(
                 self._project,
                 classify_outputs_archive_id,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -447,7 +447,7 @@ class MultiTable:
             self._project, str(debug_summary_path)
         )
 
-    def classify(self, config: GretelModelConfig) -> None:
+    def classify(self, config: GretelModelConfig, all_rows: bool = False) -> None:
         for table in self.relational_data.list_all_tables():
             classify_config = make_classify_config(table, config)
 
@@ -466,6 +466,7 @@ class MultiTable:
 
         task = ClassifyTask(
             classify=self._classify,
+            all_rows=all_rows,
             multitable=self,
         )
         run_task(task, self._extended_sdk)

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -60,7 +60,6 @@ def label_encode_keys(
             continue
 
         for primary_key_column in rel_data.get_primary_key(table_name):
-
             # Get a set of the tables and columns in `tables` referencing this PK
             fk_references: Set[Tuple[str, str]] = set()
             for descendant in rel_data.get_descendants(table_name):

--- a/src/gretel_trainer/relational/tasks/__init__.py
+++ b/src/gretel_trainer/relational/tasks/__init__.py
@@ -1,3 +1,4 @@
+from gretel_trainer.relational.tasks.classify import ClassifyTask
 from gretel_trainer.relational.tasks.synthetics_evaluate import SyntheticsEvaluateTask
 from gretel_trainer.relational.tasks.synthetics_run import SyntheticsRunTask
 from gretel_trainer.relational.tasks.synthetics_train import SyntheticsTrainTask

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -142,7 +142,7 @@ class ClassifyTask:
 
     def _write_results(self, job: Job, table: str) -> None:
         if isinstance(job, Model):
-            filename = f"classify_subset_{table}.gz"
+            filename = f"classify_{table}.gz"
             artifact_name = "data_preview"
         else:
             filename = f"classify_all_rows_{table}.gz"

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -1,0 +1,119 @@
+from typing import List
+
+from gretel_client.projects.jobs import Job
+from gretel_client.projects.models import Model
+from gretel_client.projects.projects import Project
+from gretel_client.projects.records import RecordHandler
+
+import gretel_trainer.relational.tasks.common as common
+from gretel_trainer.relational.workflow_state import Classify
+
+
+class ClassifyTask:
+    def __init__(
+        self,
+        classify: Classify,
+        multitable: common._MultiTable,
+    ):
+        self.classify = classify
+        self.multitable = multitable
+        self.completed_models = []
+        self.failed_models = []
+        self.completed_record_handlers = []
+        self.failed_record_handlers = []
+
+    def action(self, job: Job) -> str:
+        if isinstance(job, Model):
+            return "classify training"
+        else:
+            return "classification"
+
+    @property
+    def project(self) -> Project:
+        return self.multitable._project
+
+    @property
+    def artifacts_per_job(self) -> int:
+        return 1
+
+    @property
+    def table_collection(self) -> List[str]:
+        return list(self.classify.models.keys())
+
+    def more_to_do(self) -> bool:
+        total_tables = len(self.classify.models)
+        return (
+            len(self._finished_models) < total_tables
+            or len(self._finished_record_handlers) < total_tables
+        )
+
+    def wait(self) -> None:
+        # Classify training is fast
+        if len(self._finished_models) < len(self.classify.models):
+            duration = 15
+        else:
+            duration = self.multitable._refresh_interval
+        common.wait(duration)
+
+    @property
+    def _finished_models(self) -> List[str]:
+        return self.completed_models + self.failed_models
+
+    @property
+    def _finished_record_handlers(self) -> List[str]:
+        return self.completed_record_handlers + self.failed_record_handlers
+
+    def is_finished(self, table: str) -> bool:
+        return (
+            table in self._finished_models and table in self._finished_record_handlers
+        )
+
+    def get_job(self, table: str) -> Job:
+        record_handler = self.classify.record_handlers.get(table)
+        model = self.classify.models.get(table)
+        return record_handler or model
+
+    def handle_completed(self, table: str, job: Job) -> None:
+        if isinstance(job, Model):
+            self.completed_models.append(table)
+            common.log_success(table, self.action(job))
+            record_handler = job.create_record_handler_obj(data_source=job.data_source)
+            self.classify.record_handlers[table] = record_handler
+            self.multitable._extended_sdk.start_job_if_possible(
+                job=record_handler,
+                table_name=table,
+                action=self.action(record_handler),
+                project=self.project,
+                number_of_artifacts=self.artifacts_per_job,
+            )
+        elif isinstance(job, RecordHandler):
+            self.completed_record_handlers.append(table)
+            common.log_success(table, self.action(job))
+            common.cleanup(
+                sdk=self.multitable._extended_sdk, project=self.project, job=job
+            )
+
+    def handle_failed(self, table: str, job: Job) -> None:
+        if isinstance(job, Model):
+            self.failed_models.append(table)
+        elif isinstance(job, RecordHandler):
+            self.failed_record_handlers.append(table)
+        common.log_failed(table, self.action(job))
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
+
+    def handle_lost_contact(self, table: str, job: Job) -> None:
+        if isinstance(job, Model):
+            self.failed_models.append(table)
+            self.classify.lost_models.append(table)
+        elif isinstance(job, RecordHandler):
+            self.failed_record_handlers.append(table)
+            self.classify.lost_record_handlers.append(table)
+        common.log_lost_contact(table)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
+
+    def handle_in_progress(self, table: str, job: Job) -> None:
+        action = self.action(job)
+        common.log_in_progress(table, job.status, action)
+
+    def each_iteration(self) -> None:
+        self.multitable._backup()

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import smart_open
 from gretel_client.projects.jobs import Job
@@ -28,7 +28,7 @@ class ClassifyTask:
         self.failed_models = []
         self.completed_record_handlers = []
         self.failed_record_handlers = []
-        self.result_filepaths = {}
+        self.result_filepaths: Dict[str, Path] = {}
 
     def action(self, job: Job) -> str:
         if self.all_rows:
@@ -147,9 +147,10 @@ class ClassifyTask:
         self.multitable._backup()
 
     def _write_results(self, job: Job, artifact: str, table: str) -> None:
-        destpath = str(self.out_dir / f"classify_{table}.gz")
+        filename = f"classify_{table}.gz"
+        destpath = self.out_dir / filename
         with smart_open.open(
             job.get_artifact_link(artifact), "rb"
-        ) as src, smart_open.open(destpath, "wb") as dest:
+        ) as src, smart_open.open(str(destpath), "wb") as dest:
             shutil.copyfileobj(src, dest)
-        self.result_filepaths[table] = destpath
+        self.result_filepaths[filename] = destpath

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -145,10 +145,10 @@ class ClassifyTask:
 
     def _write_results(self, job: Job, table: str) -> None:
         if isinstance(job, Model):
-            filename = f"classify_first100_{table}.gz"
+            filename = f"classify_subset_{table}.gz"
             artifact_name = "data_preview"
         else:
-            filename = f"classify_complete_{table}.gz"
+            filename = f"classify_all_rows_{table}.gz"
             artifact_name = "data"
 
         destpath = self.out_dir / filename

--- a/src/gretel_trainer/relational/tasks/common.py
+++ b/src/gretel_trainer/relational/tasks/common.py
@@ -1,5 +1,8 @@
+import logging
+import time
 from typing import Union
 
+from gretel_client.projects.jobs import Job, Status
 from gretel_client.projects.projects import Project
 from typing_extensions import Protocol
 
@@ -7,6 +10,8 @@ from gretel_trainer.relational.core import RelationalData
 from gretel_trainer.relational.sdk_extras import ExtendedGretelSDK
 from gretel_trainer.relational.strategies.ancestral import AncestralStrategy
 from gretel_trainer.relational.strategies.independent import IndependentStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class _MultiTable(Protocol):
@@ -32,3 +37,30 @@ class _MultiTable(Protocol):
 
     def _backup(self) -> None:
         ...
+
+
+def wait(seconds: int) -> None:
+    logger.info(f"Next status check in {seconds} seconds.")
+    time.sleep(seconds)
+
+
+def log_in_progress(table_name: str, status: Status, action: str) -> None:
+    logger.info(
+        f"{action.capitalize()} job for `{table_name}` still in progress (status: {status})."
+    )
+
+
+def log_success(table_name: str, action: str) -> None:
+    logger.info(f"{action.capitalize()} successfully completed for `{table_name}`.")
+
+
+def log_failed(table_name: str, action: str) -> None:
+    logger.info(f"{action.capitalize()} failed for `{table_name}`.")
+
+
+def log_lost_contact(table_name: str) -> None:
+    logger.warning(f"Lost contact with job for `{table_name}`.")
+
+
+def cleanup(sdk: ExtendedGretelSDK, project: Project, job: Job) -> None:
+    sdk.delete_data_source(project, job)

--- a/src/gretel_trainer/relational/tasks/synthetics_evaluate.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_evaluate.py
@@ -4,7 +4,9 @@ from gretel_client.projects.jobs import Job
 from gretel_client.projects.models import Model
 from gretel_client.projects.projects import Project
 
-from gretel_trainer.relational.tasks.common import _MultiTable
+import gretel_trainer.relational.tasks.common as common
+
+ACTION = "synthetic data evaluation"
 
 
 class SyntheticsEvaluateTask:
@@ -12,7 +14,7 @@ class SyntheticsEvaluateTask:
         self,
         evaluate_models: Dict[str, Model],
         project: Project,
-        multitable: _MultiTable,
+        multitable: common._MultiTable,
     ):
         self.evaluate_models = evaluate_models
         self.project = project
@@ -20,13 +22,8 @@ class SyntheticsEvaluateTask:
         self.completed = []
         self.failed = []
 
-    @property
-    def action(self) -> str:
-        return "synthetic data evaluation"
-
-    @property
-    def refresh_interval(self) -> int:
-        return 20
+    def action(self, job: Job) -> str:
+        return ACTION
 
     @property
     def table_collection(self) -> List[str]:
@@ -39,6 +36,9 @@ class SyntheticsEvaluateTask:
     def more_to_do(self) -> bool:
         return len(self.completed + self.failed) < len(self.evaluate_models)
 
+    def wait(self) -> None:
+        common.wait(20)
+
     def is_finished(self, table: str) -> bool:
         return table in (self.completed + self.failed)
 
@@ -47,12 +47,21 @@ class SyntheticsEvaluateTask:
 
     def handle_completed(self, table: str, job: Job) -> None:
         self.completed.append(table)
+        common.log_success(table, ACTION)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
 
-    def handle_failed(self, table: str) -> None:
+    def handle_failed(self, table: str, job: Job) -> None:
         self.failed.append(table)
+        common.log_failed(table, ACTION)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
 
-    def handle_lost_contact(self, table: str) -> None:
+    def handle_lost_contact(self, table: str, job: Job) -> None:
         self.failed.append(table)
+        common.log_lost_contact(table)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
+
+    def handle_in_progress(self, table: str, job: Job) -> None:
+        common.log_in_progress(table, job.status, ACTION)
 
     def each_iteration(self) -> None:
         pass

--- a/src/gretel_trainer/relational/tasks/synthetics_train.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_train.py
@@ -3,28 +3,25 @@ from typing import List
 from gretel_client.projects.jobs import Job
 from gretel_client.projects.projects import Project
 
-from gretel_trainer.relational.tasks.common import _MultiTable
+import gretel_trainer.relational.tasks.common as common
 from gretel_trainer.relational.workflow_state import SyntheticsTrain
+
+ACTION = "synthetics model training"
 
 
 class SyntheticsTrainTask:
     def __init__(
         self,
         synthetics_train: SyntheticsTrain,
-        multitable: _MultiTable,
+        multitable: common._MultiTable,
     ):
         self.synthetics_train = synthetics_train
         self.multitable = multitable
         self.completed = []
         self.failed = []
 
-    @property
-    def action(self) -> str:
-        return "synthetics model training"
-
-    @property
-    def refresh_interval(self) -> int:
-        return self.multitable._refresh_interval
+    def action(self, job: Job) -> str:
+        return ACTION
 
     @property
     def project(self) -> Project:
@@ -41,6 +38,9 @@ class SyntheticsTrainTask:
     def more_to_do(self) -> bool:
         return len(self.completed + self.failed) < len(self.synthetics_train.models)
 
+    def wait(self) -> None:
+        common.wait(self.multitable._refresh_interval)
+
     def is_finished(self, table: str) -> bool:
         return table in (self.completed + self.failed)
 
@@ -49,13 +49,22 @@ class SyntheticsTrainTask:
 
     def handle_completed(self, table: str, job: Job) -> None:
         self.completed.append(table)
+        common.log_success(table, ACTION)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
 
-    def handle_failed(self, table: str) -> None:
+    def handle_failed(self, table: str, job: Job) -> None:
         self.failed.append(table)
+        common.log_failed(table, ACTION)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
 
-    def handle_lost_contact(self, table: str) -> None:
+    def handle_lost_contact(self, table: str, job: Job) -> None:
         self.synthetics_train.lost_contact.append(table)
         self.failed.append(table)
+        common.log_lost_contact(table)
+        common.cleanup(sdk=self.multitable._extended_sdk, project=self.project, job=job)
+
+    def handle_in_progress(self, table: str, job: Job) -> None:
+        common.log_in_progress(table, job.status, ACTION)
 
     def each_iteration(self) -> None:
         self.multitable._backup()

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -6,14 +6,6 @@ from gretel_client.projects.records import RecordHandler
 
 
 @dataclass
-class Classify:
-    models: Dict[str, Model] = field(default_factory=dict)
-    lost_models: List[str] = field(default_factory=list)
-    record_handlers: Dict[str, RecordHandler] = field(default_factory=dict)
-    lost_record_handlers: List[str] = field(default_factory=list)
-
-
-@dataclass
 class TransformsTrain:
     models: Dict[str, Model] = field(default_factory=dict)
     lost_contact: List[str] = field(default_factory=list)

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -6,6 +6,11 @@ from gretel_client.projects.records import RecordHandler
 
 
 @dataclass
+class Classify:
+    models: Dict[str, Model] = field(default_factory=dict)
+
+
+@dataclass
 class TransformsTrain:
     models: Dict[str, Model] = field(default_factory=dict)
     lost_contact: List[str] = field(default_factory=list)

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -6,6 +6,14 @@ from gretel_client.projects.records import RecordHandler
 
 
 @dataclass
+class Classify:
+    models: Dict[str, Model] = field(default_factory=dict)
+    lost_models: List[str] = field(default_factory=list)
+    record_handlers: Dict[str, RecordHandler] = field(default_factory=dict)
+    lost_record_handlers: List[str] = field(default_factory=list)
+
+
+@dataclass
 class TransformsTrain:
     models: Dict[str, Model] = field(default_factory=dict)
     lost_contact: List[str] = field(default_factory=list)

--- a/tests/relational/test_artifacts.py
+++ b/tests/relational/test_artifacts.py
@@ -25,6 +25,25 @@ def test_appends_to_existing_archive():
             assert len(tar.getnames()) == 2
 
 
+def test_overwrites_existing_file_in_archive():
+    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1:
+        archive_path = Path(tmpdir) / "archive.tar.gz"
+        add_to_tar(archive_path, Path(tf1.name), "tf1")
+        add_to_tar(archive_path, Path(tf1.name), "tf1")
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            assert len(tar.getnames()) == 1
+
+    # Overwrite is based on provided arcname, not file contents
+    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
+        archive_path = Path(tmpdir) / "archive.tar.gz"
+        add_to_tar(archive_path, Path(tf1.name), "name")
+        add_to_tar(archive_path, Path(tf2.name), "name")
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            assert len(tar.getnames()) == 1
+
+
 def test_uploads_path_to_project_and_stores_artifact_key():
     ac = ArtifactCollection(hybrid=False)
     project = Mock()

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -3,6 +3,7 @@ import json
 from gretel_trainer.relational.artifacts import ArtifactCollection
 from gretel_trainer.relational.backup import (
     Backup,
+    BackupClassify,
     BackupForeignKey,
     BackupGenerate,
     BackupRelationalData,
@@ -50,6 +51,12 @@ def test_backup():
             )
         ],
     )
+    backup_classify = BackupClassify(
+        model_ids={
+            "customer": "aaabbbccc",
+            "address": "dddeeefff",
+        },
+    )
     backup_transforms_train = BackupTransformsTrain(
         model_ids={
             "customer": "222333444",
@@ -92,6 +99,7 @@ def test_backup():
         refresh_interval=120,
         artifact_collection=artifact_collection,
         relational_data=backup_relational,
+        classify=backup_classify,
         transforms_train=backup_transforms_train,
         synthetics_train=backup_synthetics_train,
         generate=backup_generate,


### PR DESCRIPTION
Adds support for classify!

- At the public interface level, just a single method: `classify`
- Takes one classify config and applies it to all tables
- By default, only creates and trains models. Classify training produces a "data preview" that is the classification results for the first 100 records from the data source. In many cases this is all a user needs to identify columns of interest/concern.
- Optionally pass `all_rows=True` to run record handler jobs after training completes; the data results contain all records.
- Results are put in a new archive file called `classify_outputs.tar.gz`, which is uploaded to the project
  - By default, this archive will only contain `classify_{table}.gz` files
  - If `all_rows=True`, the archive will contain ^^ plus `classify_all_rows_{table}.gz` files
- We don't load/expose the results into memory—all we do is download the data result files for the user and put them in the working directory. There are two main reasons for this:
  - There isn't an especially obvious/convenient way to display the results (which are in JSONL format)—we could parse into a list of dictionaries, but bleh; it'd also be gigantic output (Maarten prints the first 5 in his notebook)
  - We want to avoid unnecessarily loading a bunch of data into memory
- The Classify model IDs are kept in memory so if you call `classify()` a second time we don't retrain. This seems particularly useful in the case of a user looking at the subset results (from training only) and wanting to subsequently run with `all_rows=True`—in that case they'll jump straight to the record handler and not have to retrain.
  - This is also supported through the restore workflow; in other words, we include classify model IDs in the backup data. As usual, if a classify outputs archive file exists in the project we will download and unpack it (cloud only, not hybrid).


There's quite a bit of additional noise here because I refactored the `Task` abstraction and `run_task` function, which meant slightly tweaking all the current tasks (synthetics train, transforms run, etc.). These changes were primarily to support a single Task (classify) being able to run both models and record handlers. This sets us up to potentially consolidate current multi-method workflows into single-method workflows, for example:
```
train_transform_models + run_transforms => transform
train + generate => synthesize
```