### PR TITLE
Pin pyright to 1.1.305

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ black
 isort
 lxml
 pandas-stubs
-pyright
+pyright==1.1.305
 pytest


### PR DESCRIPTION
The [latest release (1.1.306)](https://github.com/microsoft/pyright/releases/tag/1.1.306) of pyright includes several bug fixes that expose quite a few more type hint issues in this codebase. As a short term fix, I'm pinning pyright to the previous version to unblock higher-priority work; we can come back to address these some other time.

Many (but not all) of the new warnings from the latest pyright fall into a few categories:
- `Job` vs. `Model | RecordHandler`
- `smart_open` context managers (I think this might be a new bug on pyright's side? The message seems wrong to me)
- Several places where we hint job IDs as `str` but pyright thinks they are `str | None` (which is fair—IDs are None when first created and only get created once the job is submitted) 