### PR TITLE
Restore old FK interface but with deprecation warnings

### DIFF
--- a/notebooks/relational.ipynb
+++ b/notebooks/relational.ipynb
@@ -181,7 +181,7 @@
     "    rel_data.add_table(name=table, primary_key=pk, data=pd.read_csv(f\"{csv_dir}/{table}.csv\"))\n",
     "\n",
     "for foreign_key in foreign_keys:\n",
-    "    rel_data.add_foreign_key(**foreign_key)"
+    "    rel_data.add_foreign_key_constraint(**foreign_key)"
    ]
   },
   {

--- a/src/gretel_trainer/relational/connectors.py
+++ b/src/gretel_trainer/relational/connectors.py
@@ -69,7 +69,7 @@ class Connector:
 
         for foreign_key in foreign_keys:
             table, fk = foreign_key
-            relational_data.add_foreign_key(
+            relational_data.add_foreign_key_constraint(
                 table=table,
                 constrained_columns=fk["constrained_columns"],
                 referred_table=fk["referred_table"],

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -89,7 +89,26 @@ class RelationalData:
         else:
             return key
 
-    def add_foreign_key(
+    def add_foreign_key(self, *, foreign_key: str, referencing: str) -> None:
+        """
+        DEPRECATED: Please use `add_foreign_key_constraint` instead.
+
+        Format of both str arguments should be `table_name.column_name`
+        """
+        logger.warning(
+            "This method is deprecated and will be removed in a future release. "
+            "Please use `add_foreign_key_constraint` instead."
+        )
+        fk_table, fk_column = foreign_key.split(".")
+        referred_table, referred_column = referencing.split(".")
+        self.add_foreign_key_constraint(
+            table=fk_table,
+            constrained_columns=[fk_column],
+            referred_table=referred_table,
+            referred_columns=[referred_column],
+        )
+
+    def add_foreign_key_constraint(
         self,
         *,
         table: str,
@@ -153,7 +172,22 @@ class RelationalData:
         edge["via"] = via
         self._clear_safe_ancestral_seed_columns(table)
 
-    def remove_foreign_key(self, table: str, constrained_columns: List[str]) -> None:
+    def remove_foreign_key(self, foreign_key: str) -> None:
+        """
+        DEPRECATED: Please use `remove_foreign_key_constraint` instead.
+        """
+        logger.warning(
+            "This method is deprecated and will be removed in a future release. "
+            "Please use `remove_foreign_key_constraint` instead."
+        )
+        fk_table, fk_column = foreign_key.split(".")
+        self.remove_foreign_key_constraint(
+            table=fk_table, constrained_columns=[fk_column]
+        )
+
+    def remove_foreign_key_constraint(
+        self, table: str, constrained_columns: List[str]
+    ) -> None:
         """
         Remove an existing foreign key.
         """
@@ -356,7 +390,7 @@ class RelationalData:
                 name=table_name, primary_key=primary_key, data=data
             )
         for foreign_key in d["foreign_keys"]:
-            relational_data.add_foreign_key(
+            relational_data.add_foreign_key_constraint(
                 table=foreign_key["table"],
                 constrained_columns=foreign_key["constrained_columns"],
                 referred_table=foreign_key["referred_table"],

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -150,7 +150,7 @@ class MultiTable:
                 name=table_name, primary_key=table_backup.primary_key, data=source_data
             )
         for fk_backup in backup.relational_data.foreign_keys:
-            self.relational_data.add_foreign_key(
+            self.relational_data.add_foreign_key_constraint(
                 table=fk_backup.table,
                 constrained_columns=fk_backup.constrained_columns,
                 referred_table=fk_backup.referred_table,

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -123,13 +123,13 @@ def _setup_nba(
     rel_data.add_table(name="states", primary_key="id", data=states)
     rel_data.add_table(name="cities", primary_key="id", data=cities)
     rel_data.add_table(name="teams", primary_key="id", data=teams)
-    rel_data.add_foreign_key(
+    rel_data.add_foreign_key_constraint(
         table="teams",
         constrained_columns=["city_id"],
         referred_table="cities",
         referred_columns=["id"],
     )
-    rel_data.add_foreign_key(
+    rel_data.add_foreign_key_constraint(
         table="cities",
         constrained_columns=["state_id"],
         referred_table="states",


### PR DESCRIPTION
An earlier branch that has been merged to `main` but not yet released included a breaking change to the `add_foreign_key` method. This PR restores the original method signature (for backwards compatibility) with a deprecation warning (docstring + logged), and introduces a new method (same name plus the `_constraint` suffix) with the preferred (more explicit, less magical, supports composite keys) arguments.