### PR TITLE
Single transforms config

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -456,6 +456,16 @@ class RelationalData:
             and self.graph.nodes[table]["metadata"].invented_table_metadata is not None
         )
 
+    def get_modelable_table_names(self, table: str) -> list[str]:
+        """Returns a list of MODELABLE table names connected to the provided table.
+        If the provided table is already modelable, returns [table].
+        If the provided table is not modelable (e.g. source with JSON) returns invented tables from that source.
+        """
+        if (rel_json := self.relational_jsons.get(table)) is not None:
+            return rel_json.table_names
+        else:
+            return [table]
+
     def get_public_name(self, table: str) -> Optional[str]:
         if table in self.relational_jsons:
             return table

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -651,6 +651,18 @@ class RelationalData:
         }
 
 
+def skip_table(
+    table: str, only: Optional[list[str]], ignore: Optional[list[str]]
+) -> bool:
+    skip = False
+    if only is not None and table not in only:
+        skip = True
+    if ignore is not None and table in ignore:
+        skip = True
+
+    return skip
+
+
 def _ok_for_train_and_seed(col: str, df: pd.DataFrame) -> bool:
     if _is_highly_nan(col, df):
         return False

--- a/tests/relational/test_relational_data.py
+++ b/tests/relational/test_relational_data.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import pandas as pd
 import pytest
 

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -108,6 +108,20 @@ def test_list_tables_accepts_various_scopes(documents):
     )
 
 
+def test_get_modelable_table_names(documents):
+    # Given a source-with-JSON name, returns the tables invented from that source
+    assert set(documents.get_modelable_table_names("purchases")) == {
+        "purchases-sfx",
+        "purchases-data-years-sfx",
+    }
+
+    # Invented tables are modelable
+    assert documents.get_modelable_table_names("purchases-sfx") == ["purchases-sfx"]
+    assert documents.get_modelable_table_names("purchases-data-years-sfx") == [
+        "purchases-data-years-sfx"
+    ]
+
+
 def test_invented_json_column_names(documents, bball):
     # The root invented table adds columns for dictionary properties lifted from nested JSON objects
     assert set(documents.get_table_columns("purchases-sfx")) == {


### PR DESCRIPTION
Adds a new method, `train_transforms`, that accepts a single Transforms model config and applies it to all tables. This method accepts an optional list of tables passed as either `only` or `ignore` to limit which tables are trained. (These arguments match the optional list arguments on the Relational Trainer Connector's `extract` method.)

Users can include the name of a table as it appears in their db in the `only|ignore` argument and we will automatically extend that "request" to tables we invented from that source table (due to JSON). For example, if a `purchases` table had nested JSON and we ended up inventing 3 tables when we normalized that JSON data, the user can just pass the name `purchases` to explicitly include/exclude that table—they don't need to know the exact names of the tables we created under the hood.

This method will eventually fully replace `train_transform_models`, which is marked for deprecation here.

While here, updated a few of the type hints to the new style.