### PR TITLE
Kill off all the old style types in Relational code

### DIFF
--- a/src/gretel_trainer/relational/ancestry.py
+++ b/src/gretel_trainer/relational/ancestry.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import pandas as pd
 
@@ -13,7 +13,7 @@ _END_LINEAGE = "|"
 
 def get_multigenerational_primary_key(
     rel_data: RelationalData, table: str
-) -> List[str]:
+) -> list[str]:
     return [
         f"{_START_LINEAGE}{_END_LINEAGE}{pk}" for pk in rel_data.get_primary_key(table)
     ]
@@ -21,8 +21,8 @@ def get_multigenerational_primary_key(
 
 def get_ancestral_foreign_key_maps(
     rel_data: RelationalData, table: str
-) -> List[Tuple[str, str]]:
-    def _ancestral_fk_map(fk: ForeignKey) -> List[Tuple[str, str]]:
+) -> list[tuple[str, str]]:
+    def _ancestral_fk_map(fk: ForeignKey) -> list[tuple[str, str]]:
         maps = []
         fk_lineage = _COL_DELIMITER.join(fk.columns)
 
@@ -49,7 +49,7 @@ def get_ancestral_foreign_key_maps(
 def get_table_data_with_ancestors(
     rel_data: RelationalData,
     table: str,
-    tableset: Optional[Dict[str, pd.DataFrame]] = None,
+    tableset: Optional[dict[str, pd.DataFrame]] = None,
     ancestral_seeding: bool = False,
 ) -> pd.DataFrame:
     """
@@ -75,7 +75,7 @@ def _join_parents(
     df: pd.DataFrame,
     table: str,
     lineage: str,
-    tableset: Optional[Dict[str, pd.DataFrame]],
+    tableset: Optional[dict[str, pd.DataFrame]],
     ancestral_seeding: bool,
 ) -> pd.DataFrame:
     for foreign_key in rel_data.get_foreign_keys(table):
@@ -134,7 +134,7 @@ def drop_ancestral_data(df: pd.DataFrame) -> pd.DataFrame:
     return df[root_columns].rename(columns=mapper)
 
 
-def prepend_foreign_key_lineage(df: pd.DataFrame, fk_cols: List[str]) -> pd.DataFrame:
+def prepend_foreign_key_lineage(df: pd.DataFrame, fk_cols: list[str]) -> pd.DataFrame:
     """
     Given a multigenerational dataframe, renames all columns such that the provided
     foreign key columns act as the lineage from some child table to the provided data.

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from gretel_trainer.relational.artifacts import ArtifactCollection
 from gretel_trainer.relational.core import ForeignKey, RelationalData
@@ -9,16 +9,16 @@ from gretel_trainer.relational.core import ForeignKey, RelationalData
 
 @dataclass
 class BackupRelationalDataTable:
-    primary_key: List[str]
+    primary_key: list[str]
     invented_table_metadata: Optional[dict[str, str]] = None
 
 
 @dataclass
 class BackupForeignKey:
     table: str
-    constrained_columns: List[str]
+    constrained_columns: list[str]
     referred_table: str
-    referred_columns: List[str]
+    referred_columns: list[str]
 
     @classmethod
     def from_fk(cls, fk: ForeignKey) -> BackupForeignKey:
@@ -41,9 +41,9 @@ class BackupRelationalJson:
 
 @dataclass
 class BackupRelationalData:
-    tables: Dict[str, BackupRelationalDataTable]
-    foreign_keys: List[BackupForeignKey]
-    relational_jsons: Dict[str, BackupRelationalJson]
+    tables: dict[str, BackupRelationalDataTable]
+    foreign_keys: list[BackupForeignKey]
+    relational_jsons: dict[str, BackupRelationalJson]
 
     @classmethod
     def from_relational_data(cls, rel_data: RelationalData) -> BackupRelationalData:
@@ -80,30 +80,30 @@ class BackupRelationalData:
 
 @dataclass
 class BackupClassify:
-    model_ids: Dict[str, str]
+    model_ids: dict[str, str]
 
 
 @dataclass
 class BackupTransformsTrain:
-    model_ids: Dict[str, str]
-    lost_contact: List[str]
+    model_ids: dict[str, str]
+    lost_contact: list[str]
 
 
 @dataclass
 class BackupSyntheticsTrain:
-    model_ids: Dict[str, str]
-    lost_contact: List[str]
-    training_columns: Dict[str, List[str]]
+    model_ids: dict[str, str]
+    lost_contact: list[str]
+    training_columns: dict[str, list[str]]
 
 
 @dataclass
 class BackupGenerate:
     identifier: str
-    preserved: List[str]
+    preserved: list[str]
     record_size_ratio: float
-    record_handler_ids: Dict[str, str]
-    lost_contact: List[str]
-    missing_model: List[str]
+    record_handler_ids: dict[str, str]
+    lost_contact: list[str]
+    missing_model: list[str]
 
 
 @dataclass
@@ -125,7 +125,7 @@ class Backup:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, b: Dict[str, Any]):
+    def from_dict(cls, b: dict[str, Any]):
         relational_data = b["relational_data"]
         brd = BackupRelationalData(
             tables={

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import networkx
 import pandas as pd
@@ -25,18 +25,18 @@ class MultiTableException(Exception):
     pass
 
 
-GretelModelConfig = Union[str, Path, Dict]
+GretelModelConfig = Union[str, Path, dict]
 
 
 @dataclass
 class ForeignKey:
     table_name: str
-    columns: List[str]
+    columns: list[str]
     parent_table_name: str
-    parent_columns: List[str]
+    parent_columns: list[str]
 
 
-UserFriendlyPrimaryKeyT = Optional[Union[str, List[str]]]
+UserFriendlyPrimaryKeyT = Optional[Union[str, list[str]]]
 
 
 class Scope(str, Enum):
@@ -234,7 +234,7 @@ class RelationalData:
 
         return original_data, original_primary_key, original_foreign_keys
 
-    def _format_key_column(self, key: Optional[Union[str, List[str]]]) -> List[str]:
+    def _format_key_column(self, key: Optional[Union[str, list[str]]]) -> list[str]:
         if key is None:
             return []
         elif isinstance(key, str):
@@ -265,9 +265,9 @@ class RelationalData:
         self,
         *,
         table: str,
-        constrained_columns: List[str],
+        constrained_columns: list[str],
         referred_table: str,
-        referred_columns: List[str],
+        referred_columns: list[str],
     ) -> None:
         """
         Add a foreign key relationship between two tables.
@@ -342,7 +342,7 @@ class RelationalData:
         )
 
     def remove_foreign_key_constraint(
-        self, table: str, constrained_columns: List[str]
+        self, table: str, constrained_columns: list[str]
     ) -> None:
         """
         Remove an existing foreign key.
@@ -420,7 +420,7 @@ class RelationalData:
                 metadata.columns = set(data.columns)
                 self._clear_safe_ancestral_seed_columns(table)
 
-    def list_all_tables(self, scope: Scope = Scope.MODELABLE) -> List[str]:
+    def list_all_tables(self, scope: Scope = Scope.MODELABLE) -> list[str]:
         modelable_nodes = self.graph.nodes
 
         json_source_tables = [
@@ -488,10 +488,10 @@ class RelationalData:
 
         return self.graph.nodes[table]["metadata"].invented_table_metadata
 
-    def get_parents(self, table: str) -> List[str]:
+    def get_parents(self, table: str) -> list[str]:
         return list(self.graph.successors(table))
 
-    def get_ancestors(self, table: str) -> List[str]:
+    def get_ancestors(self, table: str) -> list[str]:
         def _add_parents(ancestors, table):
             parents = self.get_parents(table)
             if len(parents) > 0:
@@ -504,7 +504,7 @@ class RelationalData:
 
         return list(ancestors)
 
-    def get_descendants(self, table: str) -> List[str]:
+    def get_descendants(self, table: str) -> list[str]:
         def _add_children(descendants, table):
             children = list(self.graph.predecessors(table))
             if len(children) > 0:
@@ -517,7 +517,7 @@ class RelationalData:
 
         return list(descendants)
 
-    def list_tables_parents_before_children(self) -> List[str]:
+    def list_tables_parents_before_children(self) -> list[str]:
         """
         Returns a list of all tables with the guarantee that a parent table
         appears before any of its children. No other guarantees about order
@@ -526,7 +526,7 @@ class RelationalData:
         """
         return list(reversed(list(topological_sort(self.graph))))
 
-    def get_primary_key(self, table: str) -> List[str]:
+    def get_primary_key(self, table: str) -> list[str]:
         try:
             return self.graph.nodes[table]["metadata"].primary_key
         except KeyError:
@@ -592,7 +592,7 @@ class RelationalData:
 
     def get_foreign_keys(
         self, table: str, rename_invented_tables: bool = False
-    ) -> List[ForeignKey]:
+    ) -> list[ForeignKey]:
         def _rename_invented(fk: ForeignKey) -> ForeignKey:
             table_name = fk.table_name
             parent_table_name = fk.parent_table_name
@@ -619,14 +619,14 @@ class RelationalData:
         else:
             return foreign_keys
 
-    def get_all_key_columns(self, table: str) -> List[str]:
+    def get_all_key_columns(self, table: str) -> list[str]:
         all_key_cols = []
         all_key_cols.extend(self.get_primary_key(table))
         for fk in self.get_foreign_keys(table):
             all_key_cols.extend(fk.columns)
         return all_key_cols
 
-    def debug_summary(self) -> Dict[str, Any]:
+    def debug_summary(self) -> dict[str, Any]:
         max_depth = dag_longest_path_length(self.graph)
         public_table_count = len(self.list_all_tables(Scope.PUBLIC))
         invented_table_count = len(self.list_all_tables(Scope.INVENTED))

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, List
+from typing import Any
 
 from gretel_client.projects.models import read_model_config
 
@@ -10,7 +10,7 @@ from gretel_trainer.relational.core import (
 )
 
 
-def _ingest(config: GretelModelConfig) -> Dict[str, Any]:
+def _ingest(config: GretelModelConfig) -> dict[str, Any]:
     return read_model_config(deepcopy(config))
 
 
@@ -19,19 +19,19 @@ def _model_name(workflow: str, table: str) -> str:
     return f"{workflow}-{ok_table_name}"
 
 
-def make_classify_config(table: str, config: GretelModelConfig) -> Dict[str, Any]:
+def make_classify_config(table: str, config: GretelModelConfig) -> dict[str, Any]:
     tailored_config = _ingest(config)
     tailored_config["name"] = _model_name("classify", table)
     return tailored_config
 
 
-def make_evaluate_config(table: str) -> Dict[str, Any]:
+def make_evaluate_config(table: str) -> dict[str, Any]:
     tailored_config = _ingest("evaluate/default")
     tailored_config["name"] = _model_name("evaluate", table)
     return tailored_config
 
 
-def make_synthetics_config(table: str, config: GretelModelConfig) -> Dict[str, Any]:
+def make_synthetics_config(table: str, config: GretelModelConfig) -> dict[str, Any]:
     tailored_config = _ingest(config)
     tailored_config["name"] = _model_name("synthetics", table)
     return tailored_config
@@ -39,7 +39,7 @@ def make_synthetics_config(table: str, config: GretelModelConfig) -> Dict[str, A
 
 def make_transform_config(
     rel_data: RelationalData, table: str, config: GretelModelConfig
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     tailored_config = _ingest(config)
     tailored_config["name"] = _model_name("transforms", table)
 
@@ -65,7 +65,7 @@ def make_transform_config(
     return tailored_config
 
 
-def _passthrough_policy(columns: List[str]) -> Dict[str, Any]:
+def _passthrough_policy(columns: list[str]) -> dict[str, Any]:
     return {
         "name": "ignore-keys",
         "rules": [

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -10,7 +10,7 @@ from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import pandas as pd
 import smart_open
@@ -101,10 +101,10 @@ class MultiTable:
         self._latest_backup: Optional[Backup] = None
         self._classify = Classify()
         self._transforms_train = TransformsTrain()
-        self.transform_output_tables: Dict[str, pd.DataFrame] = {}
+        self.transform_output_tables: dict[str, pd.DataFrame] = {}
         self._synthetics_train = SyntheticsTrain()
         self._synthetics_run: Optional[SyntheticsRun] = None
-        self.synthetic_output_tables: Dict[str, pd.DataFrame] = {}
+        self.synthetic_output_tables: dict[str, pd.DataFrame] = {}
         self._evaluations = defaultdict(lambda: TableEvaluation())
 
         if backup is None:
@@ -643,7 +643,7 @@ class MultiTable:
         self,
         identifier: Optional[str] = None,
         in_place: bool = False,
-        data: Optional[Dict[str, pd.DataFrame]] = None,
+        data: Optional[dict[str, pd.DataFrame]] = None,
     ) -> None:
         """
         identifier: (str, optional): Unique string identifying a specific call to this method. Defaults to "transforms_" + current timestamp
@@ -682,7 +682,7 @@ class MultiTable:
             df.to_csv(transforms_run_path, index=False)
             transforms_run_paths[table] = transforms_run_path
 
-        transforms_record_handlers: Dict[str, RecordHandler] = {}
+        transforms_record_handlers: dict[str, RecordHandler] = {}
 
         for table_name, transforms_run_path in transforms_run_paths.items():
             model = self._transforms_train.models[table_name]
@@ -722,7 +722,7 @@ class MultiTable:
         self._backup()
         self.transform_output_tables = reshaped_tables
 
-    def _prepare_training_data(self, tables: List[str]) -> Dict[str, Path]:
+    def _prepare_training_data(self, tables: list[str]) -> dict[str, Path]:
         """
         Exports a copy of each table prepared for training by the configured strategy
         to the working directory. Returns a dict with table names as keys and Paths
@@ -740,7 +740,7 @@ class MultiTable:
 
         return training_paths
 
-    def _train_synthetics_models(self, training_data: Dict[str, Path]) -> None:
+    def _train_synthetics_models(self, training_data: dict[str, Path]) -> None:
         for table_name, training_csv in training_data.items():
             synthetics_config = make_synthetics_config(table_name, self._model_config)
             model = self._project.create_model_obj(
@@ -783,7 +783,7 @@ class MultiTable:
         training_data = self._prepare_training_data(tables)
         self._train_synthetics_models(training_data)
 
-    def retrain_tables(self, tables: Dict[str, pd.DataFrame]) -> None:
+    def retrain_tables(self, tables: dict[str, pd.DataFrame]) -> None:
         """
         Provide updated table data and retrain. This method overwrites the table data in the
         `RelationalData` instance. It should be used when initial training fails and source data
@@ -822,7 +822,7 @@ class MultiTable:
     def generate(
         self,
         record_size_ratio: float = 1.0,
-        preserve_tables: Optional[List[str]] = None,
+        preserve_tables: Optional[list[str]] = None,
         identifier: Optional[str] = None,
         resume: bool = False,
     ) -> None:
@@ -982,7 +982,7 @@ class MultiTable:
             html_content = ReportRenderer().render(presenter)
             report.write(html_content)
 
-    def _list_tables_with_missing_models(self) -> List[str]:
+    def _list_tables_with_missing_models(self) -> list[str]:
         missing_model = set()
         for table in self.relational_data.list_all_tables():
             if not _table_trained_successfully(self._synthetics_train, table):
@@ -1015,7 +1015,7 @@ class MultiTable:
         self._evaluations[table].individual_report_json = individual_report_json
         self._evaluations[table].cross_table_report_json = cross_table_report_json
 
-    def _validate_gretel_model(self, gretel_model: Optional[str]) -> Tuple[str, str]:
+    def _validate_gretel_model(self, gretel_model: Optional[str]) -> tuple[str, str]:
         gretel_model = (gretel_model or self._strategy.default_model).lower()
         supported_models = self._strategy.supported_models
         if gretel_model not in supported_models:

--- a/src/gretel_trainer/relational/report/figures.py
+++ b/src/gretel_trainer/relational/report/figures.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional
+from typing import Optional
 
 import plotly.graph_objects as go
 
@@ -55,7 +55,7 @@ def _generate_pointer_path(score: int):
 def gauge_and_needle_chart(
     score: Optional[int],
     display_score: bool = True,
-    marker_colors: Optional[List[str]] = None,
+    marker_colors: Optional[list[str]] = None,
 ) -> go.Figure:
     """
     The 'fancy' gauge and needle chart to go with the overall score of the report.  Has colored segments for

--- a/src/gretel_trainer/relational/report/report.py
+++ b/src/gretel_trainer/relational/report/report.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from math import ceil
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import plotly.graph_objects as go
 from jinja2 import Environment, FileSystemLoader
@@ -34,8 +34,8 @@ class ReportRenderer:
 @dataclass
 class ReportTableData:
     table: str
-    pk: List[str]
-    fks: List[ForeignKey]
+    pk: list[str]
+    fks: list[ForeignKey]
 
 
 @dataclass
@@ -43,7 +43,7 @@ class ReportPresenter:
     rel_data: RelationalData
     now: datetime.datetime
     run_identifier: str
-    evaluations: Dict[str, TableEvaluation]
+    evaluations: dict[str, TableEvaluation]
 
     @property
     def generated_at(self) -> str:
@@ -54,7 +54,7 @@ class ReportPresenter:
         return self.now.strftime("%Y")
 
     @cached_property
-    def composite_sqs_score_and_grade(self) -> Tuple[Optional[int], str]:
+    def composite_sqs_score_and_grade(self) -> tuple[Optional[int], str]:
         # Add up all the non-None SQS scores and track how many there are.
         _total_score = 0
         _num_scores = 0
@@ -85,7 +85,7 @@ class ReportPresenter:
         return gauge_and_needle_chart(score)
 
     @cached_property
-    def composite_ppl_score_and_grade(self) -> Tuple[Optional[int], str]:
+    def composite_ppl_score_and_grade(self) -> tuple[Optional[int], str]:
         # Collect all the non-None PPLs, individual and cross-table.
         scores = [
             eval.individual_ppl
@@ -133,7 +133,7 @@ class ReportPresenter:
         )
 
     @property
-    def report_table_data(self) -> List[ReportTableData]:
+    def report_table_data(self) -> list[ReportTableData]:
         table_data = []
         for table in self.rel_data.list_all_tables(Scope.PUBLIC):
             pk = self.rel_data.get_primary_key(table)

--- a/src/gretel_trainer/relational/sdk_extras.py
+++ b/src/gretel_trainer/relational/sdk_extras.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import pandas as pd
 import requests
@@ -36,7 +36,7 @@ class ExtendedGretelSDK:
             project.delete_artifact(job.data_source)
 
     def cautiously_refresh_status(
-        self, job: Job, key: str, refresh_attempts: Dict[str, int]
+        self, job: Job, key: str, refresh_attempts: dict[str, int]
     ) -> Status:
         try:
             job.refresh()
@@ -73,7 +73,7 @@ class ExtendedGretelSDK:
         except:
             logger.warning(f"Failed to download `{artifact_name}`")
 
-    def sqs_score_from_full_report(self, report: Dict[str, Any]) -> Optional[int]:
+    def sqs_score_from_full_report(self, report: dict[str, Any]) -> Optional[int]:
         with suppress(KeyError):
             for field_dict in report["summary"]:
                 if field_dict["field"] == "synthetic_data_quality_score":

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import pandas as pd
 from gretel_client.projects.models import Model
@@ -24,17 +24,17 @@ class AncestralStrategy:
         return "amplify"
 
     @property
-    def supported_models(self) -> List[str]:
+    def supported_models(self) -> list[str]:
         return ["amplify"]
 
     def label_encode_keys(
-        self, rel_data: RelationalData, tables: Dict[str, pd.DataFrame]
-    ) -> Dict[str, pd.DataFrame]:
+        self, rel_data: RelationalData, tables: dict[str, pd.DataFrame]
+    ) -> dict[str, pd.DataFrame]:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
         self, rel_data: RelationalData
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         """
         Returns tables with:
         - all safe-for-seed ancestor fields added
@@ -69,8 +69,8 @@ class AncestralStrategy:
         return training_data
 
     def tables_to_retrain(
-        self, tables: List[str], rel_data: RelationalData
-    ) -> List[str]:
+        self, tables: list[str], rel_data: RelationalData
+    ) -> list[str]:
         """
         Given a set of tables requested to retrain, returns those tables with all their
         descendants, because those descendant tables were trained with data from their
@@ -82,7 +82,7 @@ class AncestralStrategy:
         return list(retrain)
 
     def validate_preserved_tables(
-        self, tables: List[str], rel_data: RelationalData
+        self, tables: list[str], rel_data: RelationalData
     ) -> None:
         """
         Ensures that for every table marked as preserved, all its ancestors are also preserved.
@@ -104,9 +104,9 @@ class AncestralStrategy:
     def ready_to_generate(
         self,
         rel_data: RelationalData,
-        in_progress: List[str],
-        finished: List[str],
-    ) -> List[str]:
+        in_progress: list[str],
+        finished: list[str],
+    ) -> list[str]:
         """
         Tables with no parents are immediately ready for generation.
         Tables with parents are ready once their parents are finished.
@@ -131,10 +131,10 @@ class AncestralStrategy:
         table: str,
         rel_data: RelationalData,
         record_size_ratio: float,
-        output_tables: Dict[str, pd.DataFrame],
+        output_tables: dict[str, pd.DataFrame],
         target_dir: Path,
-        training_columns: List[str],
-    ) -> Dict[str, Any]:
+        training_columns: list[str],
+    ) -> dict[str, Any]:
         """
         Returns kwargs for creating a record handler job via the Gretel SDK.
 
@@ -158,10 +158,10 @@ class AncestralStrategy:
     def _build_seed_data_for_table(
         self,
         table: str,
-        output_tables: Dict[str, pd.DataFrame],
+        output_tables: dict[str, pd.DataFrame],
         rel_data: RelationalData,
         synth_size: int,
-        training_columns: List[str],
+        training_columns: list[str],
     ) -> pd.DataFrame:
         seed_df = pd.DataFrame()
 
@@ -219,7 +219,7 @@ class AncestralStrategy:
 
     def tables_to_skip_when_failed(
         self, table: str, rel_data: RelationalData
-    ) -> List[str]:
+    ) -> list[str]:
         return rel_data.get_descendants(table)
 
     def post_process_individual_synthetic_result(
@@ -265,11 +265,11 @@ class AncestralStrategy:
 
     def post_process_synthetic_results(
         self,
-        synth_tables: Dict[str, pd.DataFrame],
-        preserved: List[str],
+        synth_tables: dict[str, pd.DataFrame],
+        preserved: list[str],
         rel_data: RelationalData,
         record_size_ratio: float,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         """
         Restores tables from multigenerational to original shape
         """
@@ -281,7 +281,7 @@ class AncestralStrategy:
     def update_evaluation_from_model(
         self,
         table_name: str,
-        evaluations: Dict[str, TableEvaluation],
+        evaluations: dict[str, TableEvaluation],
         model: Model,
         working_dir: Path,
         extended_sdk: ExtendedGretelSDK,
@@ -299,8 +299,8 @@ class AncestralStrategy:
         self,
         table_name: str,
         rel_data: RelationalData,
-        synthetic_tables: Dict[str, pd.DataFrame],
-    ) -> Optional[Dict[str, pd.DataFrame]]:
+        synthetic_tables: dict[str, pd.DataFrame],
+    ) -> Optional[dict[str, pd.DataFrame]]:
         return {
             "source": rel_data.get_table_data(table_name),
             "synthetic": synthetic_tables[table_name],
@@ -309,7 +309,7 @@ class AncestralStrategy:
     def update_evaluation_from_evaluate(
         self,
         table_name: str,
-        evaluations: Dict[str, TableEvaluation],
+        evaluations: dict[str, TableEvaluation],
         evaluate_model: Model,
         working_dir: Path,
         extended_sdk: ExtendedGretelSDK,
@@ -325,8 +325,8 @@ class AncestralStrategy:
 
 
 def _add_artifical_rows_for_seeding(
-    rel_data: RelationalData, tables: Dict[str, pd.DataFrame]
-) -> Dict[str, pd.DataFrame]:
+    rel_data: RelationalData, tables: dict[str, pd.DataFrame]
+) -> dict[str, pd.DataFrame]:
     # On each table, add an artifical row with the max possible PK value
     max_pk_values = {}
     for table_name, data in tables.items():
@@ -365,7 +365,7 @@ def _add_artifical_rows_for_seeding(
     return tables
 
 
-def _safe_inc(i: int, col: Union[List[Any], range]) -> int:
+def _safe_inc(i: int, col: Union[list, range]) -> int:
     i = i + 1
     if i == len(col):
         i = 0

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -3,7 +3,7 @@ import logging
 import math
 import random
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 import pandas as pd
 import smart_open
@@ -29,7 +29,7 @@ def download_artifacts(
         extended_sdk.download_file_artifact(model, artifact_name, out_path)
 
 
-def read_report_json_data(model: Model, report_path: Path) -> Optional[Dict]:
+def read_report_json_data(model: Model, report_path: Path) -> Optional[dict]:
     full_path = f"{report_path}.json"
     try:
         return json.loads(smart_open.open(full_path).read())
@@ -37,7 +37,7 @@ def read_report_json_data(model: Model, report_path: Path) -> Optional[Dict]:
         return _get_report_json(model)
 
 
-def _get_report_json(model: Model) -> Optional[Dict]:
+def _get_report_json(model: Model) -> Optional[dict]:
     try:
         return json.loads(
             smart_open.open(model.get_artifact_link("report_json")).read()
@@ -48,8 +48,8 @@ def _get_report_json(model: Model) -> Optional[Dict]:
 
 
 def label_encode_keys(
-    rel_data: RelationalData, tables: Dict[str, pd.DataFrame]
-) -> Dict[str, pd.DataFrame]:
+    rel_data: RelationalData, tables: dict[str, pd.DataFrame]
+) -> dict[str, pd.DataFrame]:
     """
     Crawls tables for all key columns (primary and foreign). For each PK (and FK columns referencing it),
     runs all values through a LabelEncoder and updates tables' columns to use LE-transformed values.
@@ -61,7 +61,7 @@ def label_encode_keys(
 
         for primary_key_column in rel_data.get_primary_key(table_name):
             # Get a set of the tables and columns in `tables` referencing this PK
-            fk_references: Set[Tuple[str, str]] = set()
+            fk_references: set[tuple[str, str]] = set()
             for descendant in rel_data.get_descendants(table_name):
                 if tables.get(descendant) is None:
                     continue
@@ -104,10 +104,10 @@ def label_encode_keys(
 def make_composite_pk_columns(
     table_name: str,
     rel_data: RelationalData,
-    primary_key: List[str],
+    primary_key: list[str],
     synth_row_count: int,
     record_size_ratio: float,
-) -> List[Tuple]:
+) -> list[tuple]:
     source_pk_columns = rel_data.get_table_data(table_name)[primary_key]
     unique_counts = source_pk_columns.nunique(axis=0)
     new_key_columns_values = []
@@ -125,5 +125,5 @@ def make_composite_pk_columns(
     return list(zip(*results))
 
 
-def get_frequencies(table_data: pd.DataFrame, cols: List[str]) -> List[int]:
+def get_frequencies(table_data: pd.DataFrame, cols: list[str]) -> list[int]:
     return list(table_data.groupby(cols).size().reset_index()[0])

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import pandas as pd
 from gretel_client.projects.models import Model
@@ -25,17 +25,17 @@ class IndependentStrategy:
         return "amplify"
 
     @property
-    def supported_models(self) -> List[str]:
+    def supported_models(self) -> list[str]:
         return ["amplify", "actgan", "lstm", "tabular-dp"]
 
     def label_encode_keys(
-        self, rel_data: RelationalData, tables: Dict[str, pd.DataFrame]
-    ) -> Dict[str, pd.DataFrame]:
+        self, rel_data: RelationalData, tables: dict[str, pd.DataFrame]
+    ) -> dict[str, pd.DataFrame]:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
         self, rel_data: RelationalData
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         """
         Returns source tables with primary and foreign keys removed
         """
@@ -55,15 +55,15 @@ class IndependentStrategy:
         return training_data
 
     def tables_to_retrain(
-        self, tables: List[str], rel_data: RelationalData
-    ) -> List[str]:
+        self, tables: list[str], rel_data: RelationalData
+    ) -> list[str]:
         """
         Returns the provided tables requested to retrain, unaltered.
         """
         return tables
 
     def validate_preserved_tables(
-        self, tables: List[str], rel_data: RelationalData
+        self, tables: list[str], rel_data: RelationalData
     ) -> None:
         """
         No-op. Under this strategy, any collection of tables can be preserved.
@@ -80,9 +80,9 @@ class IndependentStrategy:
     def ready_to_generate(
         self,
         rel_data: RelationalData,
-        in_progress: List[str],
-        finished: List[str],
-    ) -> List[str]:
+        in_progress: list[str],
+        finished: list[str],
+    ) -> list[str]:
         """
         All tables are immediately ready for generation. Once they are
         at least in progress, they are no longer ready.
@@ -98,10 +98,10 @@ class IndependentStrategy:
         table: str,
         rel_data: RelationalData,
         record_size_ratio: float,
-        output_tables: Dict[str, pd.DataFrame],
+        output_tables: dict[str, pd.DataFrame],
         target_dir: Path,
-        training_columns: List[str],
-    ) -> Dict[str, Any]:
+        training_columns: list[str],
+    ) -> dict[str, Any]:
         """
         Returns kwargs for a record handler job requesting an output record
         count based on the initial table data size and the record size ratio.
@@ -112,7 +112,7 @@ class IndependentStrategy:
 
     def tables_to_skip_when_failed(
         self, table: str, rel_data: RelationalData
-    ) -> List[str]:
+    ) -> list[str]:
         return []
 
     def post_process_individual_synthetic_result(
@@ -130,11 +130,11 @@ class IndependentStrategy:
 
     def post_process_synthetic_results(
         self,
-        synth_tables: Dict[str, pd.DataFrame],
-        preserved: List[str],
+        synth_tables: dict[str, pd.DataFrame],
+        preserved: list[str],
         rel_data: RelationalData,
         record_size_ratio: float,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         "Synthesizes primary and foreign keys"
         synth_tables = _synthesize_primary_keys(
             synth_tables, preserved, rel_data, record_size_ratio
@@ -145,7 +145,7 @@ class IndependentStrategy:
     def update_evaluation_from_model(
         self,
         table_name: str,
-        evaluations: Dict[str, TableEvaluation],
+        evaluations: dict[str, TableEvaluation],
         model: Model,
         working_dir: Path,
         extended_sdk: ExtendedGretelSDK,
@@ -163,8 +163,8 @@ class IndependentStrategy:
         self,
         table_name: str,
         rel_data: RelationalData,
-        synthetic_tables: Dict[str, pd.DataFrame],
-    ) -> Optional[Dict[str, pd.DataFrame]]:
+        synthetic_tables: dict[str, pd.DataFrame],
+    ) -> Optional[dict[str, pd.DataFrame]]:
         missing_ancestors = [
             ancestor
             for ancestor in rel_data.get_ancestors(table_name)
@@ -188,7 +188,7 @@ class IndependentStrategy:
     def update_evaluation_from_evaluate(
         self,
         table_name: str,
-        evaluations: Dict[str, TableEvaluation],
+        evaluations: dict[str, TableEvaluation],
         evaluate_model: Model,
         working_dir: Path,
         extended_sdk: ExtendedGretelSDK,
@@ -204,11 +204,11 @@ class IndependentStrategy:
 
 
 def _synthesize_primary_keys(
-    synth_tables: Dict[str, pd.DataFrame],
-    preserved: List[str],
+    synth_tables: dict[str, pd.DataFrame],
+    preserved: list[str],
     rel_data: RelationalData,
     record_size_ratio: float,
-) -> Dict[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """
     Alters primary key columns on all tables *except* preserved.
     Assumes the primary key column is of type integer.
@@ -241,8 +241,8 @@ def _synthesize_primary_keys(
 
 
 def _synthesize_foreign_keys(
-    synth_tables: Dict[str, pd.DataFrame], rel_data: RelationalData
-) -> Dict[str, pd.DataFrame]:
+    synth_tables: dict[str, pd.DataFrame], rel_data: RelationalData
+) -> dict[str, pd.DataFrame]:
     """
     Alters foreign key columns on all tables (*including* those flagged as not to
     be synthesized to ensure joining to a synthesized parent table continues to work)
@@ -282,10 +282,10 @@ def _synthesize_foreign_keys(
 
 
 def _collect_values(
-    values: List[Any],
-    frequencies: List[int],
+    values: list,
+    frequencies: list[int],
     total: int,
-) -> List[Any]:
+) -> list:
     freqs = sorted(frequencies)
 
     # Loop through frequencies in ascending order,
@@ -312,7 +312,7 @@ def _collect_values(
     return new_values
 
 
-def _safe_inc(i: int, col: List[Any]) -> int:
+def _safe_inc(i: int, col: list) -> int:
     i = i + 1
     if i == len(col):
         i = 0

--- a/src/gretel_trainer/relational/task_runner.py
+++ b/src/gretel_trainer/relational/task_runner.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from typing import Dict, List
 
 from gretel_client.projects.jobs import END_STATES, Job, Status
 from gretel_client.projects.projects import Project
@@ -18,7 +17,7 @@ class Task(Protocol):
         ...
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         ...
 
     @property
@@ -58,7 +57,7 @@ class Task(Protocol):
 
 
 def run_task(task: Task, extended_sdk: ExtendedGretelSDK) -> None:
-    refresh_attempts: Dict[str, int] = defaultdict(int)
+    refresh_attempts: dict[str, int] = defaultdict(int)
     first_pass = True
 
     while task.more_to_do():

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -1,6 +1,5 @@
 import shutil
 from pathlib import Path
-from typing import Dict, List
 
 import smart_open
 from gretel_client.projects.jobs import Job
@@ -16,7 +15,7 @@ class ClassifyTask:
     def __init__(
         self,
         classify: Classify,
-        data_sources: Dict[str, str],
+        data_sources: dict[str, str],
         all_rows: bool,
         multitable: common._MultiTable,
         out_dir: Path,
@@ -26,12 +25,12 @@ class ClassifyTask:
         self.all_rows = all_rows
         self.multitable = multitable
         self.out_dir = out_dir
-        self.classify_record_handlers: Dict[str, RecordHandler] = {}
+        self.classify_record_handlers: dict[str, RecordHandler] = {}
         self.completed_models = []
         self.failed_models = []
         self.completed_record_handlers = []
         self.failed_record_handlers = []
-        self.result_filepaths: Dict[str, Path] = {}
+        self.result_filepaths: dict[str, Path] = {}
 
     def action(self, job: Job) -> str:
         if self.all_rows:
@@ -51,7 +50,7 @@ class ClassifyTask:
         return 1
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.classify.models.keys())
 
     def more_to_do(self) -> bool:
@@ -74,11 +73,11 @@ class ClassifyTask:
         common.wait(duration)
 
     @property
-    def _finished_models(self) -> List[str]:
+    def _finished_models(self) -> list[str]:
         return self.completed_models + self.failed_models
 
     @property
-    def _finished_record_handlers(self) -> List[str]:
+    def _finished_record_handlers(self) -> list[str]:
         return self.completed_record_handlers + self.failed_record_handlers
 
     def is_finished(self, table: str) -> bool:

--- a/src/gretel_trainer/relational/tasks/synthetics_evaluate.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_evaluate.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 from gretel_client.projects.jobs import Job
 from gretel_client.projects.models import Model
 from gretel_client.projects.projects import Project
@@ -12,7 +10,7 @@ ACTION = "synthetic data evaluation"
 class SyntheticsEvaluateTask:
     def __init__(
         self,
-        evaluate_models: Dict[str, Model],
+        evaluate_models: dict[str, Model],
         project: Project,
         multitable: common._MultiTable,
     ):
@@ -26,7 +24,7 @@ class SyntheticsEvaluateTask:
         return ACTION
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.evaluate_models.keys())
 
     @property

--- a/src/gretel_trainer/relational/tasks/synthetics_run.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_run.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import pandas as pd
 from gretel_client.projects.jobs import ACTIVE_STATES, Job
@@ -29,7 +29,7 @@ class SyntheticsRunTask:
         self.multitable = multitable
         self.working_tables = self._setup_working_tables()
 
-    def _setup_working_tables(self) -> Dict[str, Optional[pd.DataFrame]]:
+    def _setup_working_tables(self) -> dict[str, Optional[pd.DataFrame]]:
         working_tables = {}
 
         for table in self.synthetics_run.missing_model:
@@ -43,7 +43,7 @@ class SyntheticsRunTask:
         return working_tables
 
     @property
-    def output_tables(self) -> Dict[str, pd.DataFrame]:
+    def output_tables(self) -> dict[str, pd.DataFrame]:
         return {
             table: data
             for table, data in self.working_tables.items()
@@ -58,7 +58,7 @@ class SyntheticsRunTask:
         return self.multitable._project
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.synthetics_run.record_handlers.keys())
 
     @property
@@ -157,7 +157,7 @@ class SyntheticsRunTask:
         self.multitable._backup()
 
     @property
-    def _all_tables(self) -> List[str]:
+    def _all_tables(self) -> list[str]:
         return self.multitable.relational_data.list_all_tables()
 
     def _fail_table(self, table: str) -> None:
@@ -176,7 +176,7 @@ def _log_skipping(skip: str, failed_parent: str) -> None:
 
 
 def _table_is_in_progress(
-    record_handlers: Dict[str, RecordHandler], table: str
+    record_handlers: dict[str, RecordHandler], table: str
 ) -> bool:
     in_progress = False
 

--- a/src/gretel_trainer/relational/tasks/synthetics_train.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_train.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from gretel_client.projects.jobs import Job
 from gretel_client.projects.projects import Project
 
@@ -28,7 +26,7 @@ class SyntheticsTrainTask:
         return self.multitable._project
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.synthetics_train.models.keys())
 
     @property

--- a/src/gretel_trainer/relational/tasks/transforms_run.py
+++ b/src/gretel_trainer/relational/tasks/transforms_run.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Optional
 
 import pandas as pd
 from gretel_client.projects.jobs import Job
@@ -13,15 +13,15 @@ ACTION = "transforms run"
 class TransformsRunTask:
     def __init__(
         self,
-        record_handlers: Dict[str, RecordHandler],
+        record_handlers: dict[str, RecordHandler],
         multitable: common._MultiTable,
     ):
         self.record_handlers = record_handlers
         self.multitable = multitable
-        self.working_tables: Dict[str, Optional[pd.DataFrame]] = {}
+        self.working_tables: dict[str, Optional[pd.DataFrame]] = {}
 
     @property
-    def output_tables(self) -> Dict[str, pd.DataFrame]:
+    def output_tables(self) -> dict[str, pd.DataFrame]:
         return {
             table: data
             for table, data in self.working_tables.items()
@@ -36,7 +36,7 @@ class TransformsRunTask:
         return self.multitable._project
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.record_handlers.keys())
 
     @property

--- a/src/gretel_trainer/relational/tasks/transforms_train.py
+++ b/src/gretel_trainer/relational/tasks/transforms_train.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from gretel_client.projects.jobs import Job
 from gretel_client.projects.projects import Project
 
@@ -28,7 +26,7 @@ class TransformsTrainTask:
         return self.multitable._project
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.transforms_train.models.keys())
 
     @property

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from gretel_client.projects.models import Model
 from gretel_client.projects.records import RecordHandler
@@ -7,27 +6,27 @@ from gretel_client.projects.records import RecordHandler
 
 @dataclass
 class Classify:
-    models: Dict[str, Model] = field(default_factory=dict)
+    models: dict[str, Model] = field(default_factory=dict)
 
 
 @dataclass
 class TransformsTrain:
-    models: Dict[str, Model] = field(default_factory=dict)
-    lost_contact: List[str] = field(default_factory=list)
+    models: dict[str, Model] = field(default_factory=dict)
+    lost_contact: list[str] = field(default_factory=list)
 
 
 @dataclass
 class SyntheticsTrain:
-    models: Dict[str, Model] = field(default_factory=dict)
-    lost_contact: List[str] = field(default_factory=list)
-    training_columns: Dict[str, List[str]] = field(default_factory=dict)
+    models: dict[str, Model] = field(default_factory=dict)
+    lost_contact: list[str] = field(default_factory=list)
+    training_columns: dict[str, list[str]] = field(default_factory=dict)
 
 
 @dataclass
 class SyntheticsRun:
     identifier: str
     record_size_ratio: float
-    preserved: List[str]
-    record_handlers: Dict[str, RecordHandler]
-    lost_contact: List[str]
-    missing_model: List[str]
+    preserved: list[str]
+    record_handlers: dict[str, RecordHandler]
+    lost_contact: list[str]
+    missing_model: list[str]

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -1,6 +1,5 @@
 import sqlite3
 from pathlib import Path
-from typing import Tuple
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -106,18 +105,18 @@ def trips() -> RelationalData:
 
 
 @pytest.fixture()
-def source_nba() -> Tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def source_nba() -> tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     return _setup_nba(synthetic=False)
 
 
 @pytest.fixture()
-def synthetic_nba() -> Tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def synthetic_nba() -> tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     return _setup_nba(synthetic=True)
 
 
 def _setup_nba(
     synthetic: bool,
-) -> Tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+) -> tuple[RelationalData, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     if synthetic:
         states = ["PA", "FL"]
         cities = ["Philadelphia", "Miami"]

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -4,7 +4,7 @@ import shutil
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -64,9 +64,9 @@ def make_backup(
     rel_data: RelationalData,
     working_dir: Path,
     artifact_collection: ArtifactCollection,
-    transforms_models: Dict[str, Mock] = {},
-    synthetics_models: Dict[str, Mock] = {},
-    synthetics_record_handlers: Dict[str, Mock] = {},
+    transforms_models: dict[str, Mock] = {},
+    synthetics_models: dict[str, Mock] = {},
+    synthetics_record_handlers: dict[str, Mock] = {},
 ) -> b.Backup:
     backup = b.Backup(
         project_name="project_name",
@@ -117,11 +117,11 @@ def write_backup(backup: b.Backup, out_dir: Path) -> str:
 def create_backup(
     rel_data: RelationalData,
     working_dir: Path,
-    synthetics_models: Dict[str, Mock] = {},
-    synthetics_record_handlers: Dict[str, Mock] = {},
+    synthetics_models: dict[str, Mock] = {},
+    synthetics_record_handlers: dict[str, Mock] = {},
     training_archive_present: bool = False,
     output_archive_present: bool = False,
-    transforms_models: Dict[str, Mock] = {},
+    transforms_models: dict[str, Mock] = {},
 ) -> str:
     artifact_collection = ArtifactCollection(
         gretel_debug_summary=ARTIFACTS["debug_summary"]["artifact_id"],
@@ -176,7 +176,7 @@ def make_mock_download_tar_artifact(setup_path: Path, working_path: Path):
     return download_tar_artifact
 
 
-def make_mock_get_model(models: Dict[str, Mock]):
+def make_mock_get_model(models: dict[str, Mock]):
     def get_model(model_id):
         return models[model_id]
 
@@ -308,7 +308,7 @@ def configure_mocks(
     download_tar_artifact: Mock,
     setup_path: Path,
     working_path: Path,
-    models: Dict[str, Mock] = {},
+    models: dict[str, Mock] = {},
 ) -> None:
     project.get_artifact_link = make_mock_get_artifact_link(setup_path)
     project.get_model = make_mock_get_model(models)

--- a/tests/relational/test_synthetics_run_task.py
+++ b/tests/relational/test_synthetics_run_task.py
@@ -1,7 +1,7 @@
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -41,8 +41,8 @@ def tmpdir():
 def make_task(
     rel_data: RelationalData,
     run_dir: Path,
-    preserved: Optional[List[str]] = None,
-    missing_model: Optional[List[str]] = None,
+    preserved: Optional[list[str]] = None,
+    missing_model: Optional[list[str]] = None,
 ) -> SyntheticsRunTask:
     multitable = MockMultiTable(relational_data=rel_data)
     return SyntheticsRunTask(

--- a/tests/relational/test_task_runner.py
+++ b/tests/relational/test_task_runner.py
@@ -1,4 +1,3 @@
-from typing import List
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -29,7 +28,7 @@ class MockTask:
         return Mock()
 
     @property
-    def table_collection(self) -> List[str]:
+    def table_collection(self) -> list[str]:
         return list(self.models.keys())
 
     def more_to_do(self) -> bool:


### PR DESCRIPTION
I had been just cleaning these as I go but it just got distracting both to myself and in PRs, so I decided to just clean it all up in one fell swoop (big thanks to [fastmod](https://github.com/facebookincubator/fastmod)).

Note: this is a branch off a branch where I had already started some of this more manually.