### PR TITLE
Preserve tables before training

### DIFF
--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -102,7 +102,6 @@ class BackupGenerate:
     record_size_ratio: float
     record_handler_ids: dict[str, str]
     lost_contact: list[str]
-    missing_model: list[str]
 
 
 @dataclass

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -93,7 +93,6 @@ class BackupTransformsTrain:
 class BackupSyntheticsTrain:
     model_ids: dict[str, str]
     lost_contact: list[str]
-    training_columns: dict[str, list[str]]
 
 
 @dataclass

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -816,7 +816,10 @@ class MultiTable:
         only: Optional[list[str]] = None,
         ignore: Optional[list[str]] = None,
     ) -> None:
-        """Train synthetic data models on each table in the relational dataset"""
+        """
+        Train synthetic data models for the tables in the tableset,
+        optionally scoped by either `only` or `ignore`.
+        """
         only, ignore = self._get_only_and_ignore(only, ignore)
 
         all_tables = self.relational_data.list_all_tables()
@@ -832,7 +835,7 @@ class MultiTable:
         # all its ancestors must also be omitted. In the future, it'd be nice to either find a way to
         # eliminate this requirement completely, or (less ideal) allow incremental training of tables,
         # e.g. train a few in one "batch", then a few more before generating (perhaps with some logs
-        # here informing the user of which required tables are missing).
+        # along the way informing the user of which required tables are missing).
         self._strategy.validate_preserved_tables(omit_tables, self.relational_data)
 
         training_data = self._prepare_training_data(include_tables)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -251,9 +251,6 @@ class MultiTable:
             with tarfile.open(synthetics_training_archive_path, "r:gz") as tar:
                 tar.extractall(path=self._working_dir)
 
-        self._synthetics_train.training_columns = (
-            backup_synthetics_train.training_columns
-        )
         self._synthetics_train.lost_contact = backup_synthetics_train.lost_contact
         self._synthetics_train.models = {
             table: self._project.get_model(model_id)
@@ -458,7 +455,6 @@ class MultiTable:
                     for table, model in self._synthetics_train.models.items()
                 },
                 lost_contact=self._synthetics_train.lost_contact,
-                training_columns=self._synthetics_train.training_columns,
             )
 
         # Generate
@@ -544,8 +540,6 @@ class MultiTable:
             if (model := state.models.get(table)) is not None:
                 model.delete()
                 del state.models[table]
-                if isinstance(state, SyntheticsTrain):
-                    del state.training_columns[table]
 
     def classify(self, config: GretelModelConfig, all_rows: bool = False) -> None:
         classify_data_sources = {}
@@ -765,8 +759,6 @@ class MultiTable:
         to the CSVs as values.
         """
         training_data = self._strategy.prepare_training_data(self.relational_data)
-        for table, df in training_data.items():
-            self._synthetics_train.training_columns[table] = list(df.columns)
         training_paths = {}
 
         for table_name in tables:
@@ -853,7 +845,6 @@ class MultiTable:
         for table in tables_to_retrain:
             with suppress(KeyError):
                 del self._synthetics_train.models[table]
-                del self._synthetics_train.training_columns[table]
         training_data = self._prepare_training_data(tables_to_retrain)
         self._train_synthetics_models(training_data)
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -758,7 +758,9 @@ class MultiTable:
         to the working directory. Returns a dict with table names as keys and Paths
         to the CSVs as values.
         """
-        training_data = self._strategy.prepare_training_data(self.relational_data)
+        training_data = self._strategy.prepare_training_data(
+            self.relational_data, tables
+        )
         training_paths = {}
 
         for table_name in tables:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -803,7 +803,13 @@ class MultiTable:
                 )
 
     def train(self) -> None:
-        """Train synthetic data models on each table in the relational dataset"""
+        """
+        DEPRECATED: Please use `train_synthetics` instead.
+        """
+        logger.warning(
+            "This method is deprecated and will be removed in a future release. "
+            "Please use `train_synthetics` instead."
+        )
         tables = self.relational_data.list_all_tables()
         self._synthetics_train = SyntheticsTrain()
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -516,6 +516,37 @@ class MultiTable:
             self._project, str(debug_summary_path)
         )
 
+    def delete_models(
+        self,
+        workflow: str,
+        *,
+        only: Optional[list[str]] = None,
+        ignore: Optional[list[str]] = None,
+    ) -> None:
+        only, ignore = self._get_only_and_ignore(only, ignore)
+        tables = [
+            table
+            for table in self.relational_data.list_all_tables()
+            if not skip_table(table, only, ignore)
+        ]
+        if workflow == "classify":
+            state = self._classify
+        elif workflow == "transforms":
+            state = self._transforms_train
+        elif workflow == "synthetics":
+            state = self._synthetics_train
+        else:
+            raise MultiTableException(
+                "Unknown workflow; must specify `classify`, `transforms`, or `synthetics`."
+            )
+
+        for table in tables:
+            if (model := state.models.get(table)) is not None:
+                model.delete()
+                del state.models[table]
+                if isinstance(state, SyntheticsTrain):
+                    del state.training_columns[table]
+
     def classify(self, config: GretelModelConfig, all_rows: bool = False) -> None:
         classify_data_sources = {}
         for table in self.relational_data.list_all_tables():

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -776,6 +776,13 @@ class MultiTable:
             )
             self._synthetics_train.models[table_name] = model
 
+        archive_path = self._working_dir / "synthetics_training.tar.gz"
+        for table_name, csv_path in training_data.items():
+            add_to_tar(archive_path, csv_path, csv_path.name)
+        self._artifact_collection.upload_synthetics_training_archive(
+            self._project, str(archive_path)
+        )
+
         self._backup()
 
         task = SyntheticsTrainTask(
@@ -794,14 +801,6 @@ class MultiTable:
                     self._working_dir,
                     self._extended_sdk,
                 )
-
-        # TODO: consider moving this to before running the task
-        archive_path = self._working_dir / "synthetics_training.tar.gz"
-        for table_name, csv_path in training_data.items():
-            add_to_tar(archive_path, csv_path, csv_path.name)
-        self._artifact_collection.upload_synthetics_training_archive(
-            self._project, str(archive_path)
-        )
 
     def train(self) -> None:
         """Train synthetic data models on each table in the relational dataset"""

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -33,7 +33,7 @@ class AncestralStrategy:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
-        self, rel_data: RelationalData
+        self, rel_data: RelationalData, tables: list[str]
     ) -> dict[str, pd.DataFrame]:
         """
         Returns tables with:
@@ -57,7 +57,7 @@ class AncestralStrategy:
         altered_tableset = _add_artifical_rows_for_seeding(rel_data, altered_tableset)
 
         # Collect all data in multigenerational format
-        for table_name in all_tables:
+        for table_name in tables:
             data = ancestry.get_table_data_with_ancestors(
                 rel_data=rel_data,
                 table=table_name,

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -52,10 +52,14 @@ class AncestralStrategy:
             altered_tableset[table_name] = rel_data.get_table_data(table_name).copy()
 
         # Translate all keys to a contiguous list of integers
-        altered_tableset = common.label_encode_keys(rel_data, altered_tableset, omit=omitted_tables)
+        altered_tableset = common.label_encode_keys(
+            rel_data, altered_tableset, omit=omitted_tables
+        )
 
         # Add artificial rows to support seeding
-        altered_tableset = _add_artifical_rows_for_seeding(rel_data, altered_tableset, omitted_tables)
+        altered_tableset = _add_artifical_rows_for_seeding(
+            rel_data, altered_tableset, omitted_tables
+        )
 
         # Collect all data in multigenerational format
         for table_name in tables:

--- a/src/gretel_trainer/relational/strategies/common.py
+++ b/src/gretel_trainer/relational/strategies/common.py
@@ -48,13 +48,19 @@ def _get_report_json(model: Model) -> Optional[dict]:
 
 
 def label_encode_keys(
-    rel_data: RelationalData, tables: dict[str, pd.DataFrame]
+    rel_data: RelationalData,
+    tables: dict[str, pd.DataFrame],
+    omit: Optional[list[str]] = None,
 ) -> dict[str, pd.DataFrame]:
     """
     Crawls tables for all key columns (primary and foreign). For each PK (and FK columns referencing it),
     runs all values through a LabelEncoder and updates tables' columns to use LE-transformed values.
     """
+    omit = omit or []
     for table_name in rel_data.list_tables_parents_before_children():
+        if table_name in omit:
+            continue
+
         df = tables.get(table_name)
         if df is None:
             continue

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -100,7 +100,6 @@ class IndependentStrategy:
         record_size_ratio: float,
         output_tables: dict[str, pd.DataFrame],
         target_dir: Path,
-        training_columns: list[str],
     ) -> dict[str, Any]:
         """
         Returns kwargs for a record handler job requesting an output record

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -34,14 +34,14 @@ class IndependentStrategy:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
-        self, rel_data: RelationalData
+        self, rel_data: RelationalData, tables: list[str]
     ) -> dict[str, pd.DataFrame]:
         """
         Returns source tables with primary and foreign keys removed
         """
         training_data = {}
 
-        for table_name in rel_data.list_all_tables():
+        for table_name in tables:
             columns_to_drop = []
             columns_to_drop.extend(rel_data.get_primary_key(table_name))
             for foreign_key in rel_data.get_foreign_keys(table_name):

--- a/src/gretel_trainer/relational/tasks/synthetics_run.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_run.py
@@ -139,7 +139,6 @@ class SyntheticsRunTask:
                 self.synthetics_run.record_size_ratio,
                 present_working_tables,
                 self.run_dir,
-                self.synthetics_train.training_columns[table_name],
             )
             model = self.synthetics_train.models[table_name]
             record_handler = model.create_record_handler_obj(**table_job)

--- a/src/gretel_trainer/relational/tasks/synthetics_run.py
+++ b/src/gretel_trainer/relational/tasks/synthetics_run.py
@@ -36,13 +36,14 @@ class SyntheticsRunTask:
         for table in all_tables:
             model = self.synthetics_train.models.get(table)
 
+            # Table was either omitted from training or marked as to-be-preserved during generation
             if model is None or table in self.synthetics_run.preserved:
                 working_tables[table] = self.multitable._strategy.get_preserved_data(
                     table, self.multitable.relational_data
                 )
 
+            # Table was included in training, but failed at that step
             elif model.status != Status.COMPLETED:
-                # model failed to train
                 working_tables[table] = None
 
         return working_tables

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -28,4 +28,3 @@ class SyntheticsRun:
     preserved: list[str]
     record_handlers: dict[str, RecordHandler]
     lost_contact: list[str]
-    missing_model: list[str]

--- a/src/gretel_trainer/relational/workflow_state.py
+++ b/src/gretel_trainer/relational/workflow_state.py
@@ -19,7 +19,6 @@ class TransformsTrain:
 class SyntheticsTrain:
     models: dict[str, Model] = field(default_factory=dict)
     lost_contact: list[str] = field(default_factory=list)
-    training_columns: dict[str, list[str]] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -339,28 +339,11 @@ def test_table_generation_readiness(ecom):
 def test_generation_job(pets):
     strategy = AncestralStrategy()
 
-    training_columns = {
-        "humans": [
-            "self|id",
-            "self|name",
-            "self|city",
-        ],
-        "pets": [
-            "self|id",
-            "self|name",
-            "self|age",
-            "self|human_id",
-            "self.human_id|id",
-            # "self.human_id|name", # highly unique categorical
-            "self.human_id|city",
-        ],
-    }
-
     # Table with no ancestors
     with tempfile.TemporaryDirectory() as tmp:
         working_dir = Path(tmp)
         parent_table_job = strategy.get_generation_job(
-            "humans", pets, 2.0, {}, working_dir, training_columns["humans"]
+            "humans", pets, 2.0, {}, working_dir
         )
         assert len(os.listdir(working_dir)) == 0
         assert parent_table_job == {"params": {"num_records": 10}}
@@ -389,7 +372,7 @@ def test_generation_job(pets):
     with tempfile.TemporaryDirectory() as tmp:
         working_dir = Path(tmp)
         child_table_job = strategy.get_generation_job(
-            "pets", pets, 2.0, output_tables, working_dir, training_columns["pets"]
+            "pets", pets, 2.0, output_tables, working_dir
         )
 
         assert len(os.listdir(working_dir)) == 1
@@ -429,29 +412,6 @@ def test_generation_job_seeds_go_back_multiple_generations(source_nba, synthetic
         "cities": ancestry.get_table_data_with_ancestors(synthetic_nba, "cities"),
         "states": ancestry.get_table_data_with_ancestors(synthetic_nba, "states"),
     }
-    training_columns = {
-        "teams": [
-            "self|name",
-            "self|id",
-            "self|city_id",
-            "self.city_id|id",
-            "self.city_id|state_id",
-            # "self.city_id|name", # highly unique categorical
-            "self.city_id.state_id|id",
-            # "self.city_id.state_id|name", # highly unique categorical
-        ],
-        "cities": [
-            "self|id",
-            "self|state_id",
-            # "self|name", # highly unique categorical
-            "self.state_id|id",
-            # "self.state_id|name", # highly unique categorical
-        ],
-        "states": [
-            "self|id",
-            "self|name",
-        ],
-    }
 
     strategy = AncestralStrategy()
 
@@ -463,7 +423,6 @@ def test_generation_job_seeds_go_back_multiple_generations(source_nba, synthetic
             1.0,
             output_tables,
             working_dir,
-            training_columns["teams"],
         )
         seed_df = pd.read_csv(job["data_source"])
 

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -33,9 +33,13 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
 def test_prepare_training_data_subset_of_tables(pets):
     strategy = AncestralStrategy()
 
-    training_data = strategy.prepare_training_data(pets, ["humans"])
+    # We aren't synthesizing the "humans" table, so it is not in the list argument
+    training_data = strategy.prepare_training_data(pets, ["pets"])
 
-    assert set(training_data.keys()) == {"humans"}
+    assert set(training_data.keys()) == {"pets"}
+    assert set(training_data["pets"]["self|human_id"].values) == {
+        1, 2, 3, 4, 5
+    }
 
 
 def test_prepare_training_data_returns_multigenerational_data(pets):

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -33,13 +33,17 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
 def test_prepare_training_data_subset_of_tables(pets):
     strategy = AncestralStrategy()
 
-    # We aren't synthesizing the "humans" table, so it is not in the list argument
+    # We aren't synthesizing the "humans" table, so it is not in this list argument...
     training_data = strategy.prepare_training_data(pets, ["pets"])
-
+    # ...nor do we create training data for it
     assert set(training_data.keys()) == {"pets"}
-    assert set(training_data["pets"]["self|human_id"].values) == {
-        1, 2, 3, 4, 5
-    }
+
+    # Since the humans table is omitted from synthetics, we leave the FK values alone; specifically:
+    # - they are not label-encoded (which would effectively zero-index them)
+    # - we do not add artificial min/max values
+    assert set(training_data["pets"]["self|human_id"].values) == {1, 2, 3, 4, 5}
+    # We do add the artificial max PK row, though, since this table is being synthesized
+    assert len(training_data["pets"]) == 6
 
 
 def test_prepare_training_data_returns_multigenerational_data(pets):

--- a/tests/relational/test_ancestry.py
+++ b/tests/relational/test_ancestry.py
@@ -187,3 +187,57 @@ def test_prepend_foreign_key_lineage(ecom):
         "self.inventory_item_id.product_id.distribution_center_id|id",
         "self.inventory_item_id.product_id.distribution_center_id|name",
     }
+
+
+def test_get_seed_safe_multigenerational_columns_1(pets):
+    table_cols = ancestry.get_seed_safe_multigenerational_columns(pets)
+
+    expected = {
+        "humans": {"self|id", "self|name", "self|city"},
+        "pets": {
+            "self|id",
+            "self|name",
+            "self|age",
+            "self|human_id",
+            "self.human_id|id",
+            # "self.human_id|name", # highly unique categorical
+            "self.human_id|city",
+        },
+    }
+
+    assert set(table_cols.keys()) == set(expected.keys())
+    for table, expected_cols in expected.items():
+        assert set(table_cols[table]) == expected_cols
+
+
+def test_get_seed_safe_multigenerational_columns_2(source_nba):
+    source_nba = source_nba[0]
+    table_cols = ancestry.get_seed_safe_multigenerational_columns(source_nba)
+
+    expected = {
+        "teams": {
+            "self|name",
+            "self|id",
+            "self|city_id",
+            "self.city_id|id",
+            "self.city_id|state_id",
+            # "self.city_id|name", # highly unique categorical
+            "self.city_id.state_id|id",
+            # "self.city_id.state_id|name", # highly unique categorical
+        },
+        "cities": {
+            "self|id",
+            "self|state_id",
+            "self|name",
+            "self.state_id|id",
+            # "self.state_id|name", # highly unique categorical
+        },
+        "states": {
+            "self|id",
+            "self|name",
+        },
+    }
+
+    assert set(table_cols.keys()) == set(expected.keys())
+    for table, expected_cols in expected.items():
+        assert set(table_cols[table]) == expected_cols

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -130,10 +130,6 @@ def test_backup():
             "customer": "1234567890",
             "address": "0987654321",
         },
-        training_columns={
-            "customer": ["id", "first", "last"],
-            "address": ["customer_id", "street", "city"],
-        },
         lost_contact=[],
     )
     backup_generate = BackupGenerate(

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -137,7 +137,6 @@ def test_backup():
         preserved=[],
         record_size_ratio=1.0,
         lost_contact=[],
-        missing_model=[],
         record_handler_ids={
             "customer": "555444666",
             "address": "333111222",

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -19,7 +19,7 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
         }
 
         strategy = IndependentStrategy()
-        strategy.prepare_training_data(rel_data)
+        strategy.prepare_training_data(rel_data, rel_data.list_all_tables())
 
         for table in rel_data.list_all_tables():
             pdtest.assert_frame_equal(
@@ -30,9 +30,17 @@ def test_preparing_training_data_does_not_mutate_source_data(pets, art):
 def test_prepare_training_data_removes_primary_and_foreign_keys(pets):
     strategy = IndependentStrategy()
 
-    training_data = strategy.prepare_training_data(pets)
+    training_data = strategy.prepare_training_data(pets, pets.list_all_tables())
 
     assert set(training_data["pets"].columns) == {"name", "age"}
+
+
+def test_prepare_training_data_subset_of_tables(pets):
+    strategy = IndependentStrategy()
+
+    training_data = strategy.prepare_training_data(pets, ["humans"])
+
+    assert set(training_data.keys()) == {"humans"}
 
 
 def test_retraining_a_set_of_tables_only_retrains_those_tables(ecom):

--- a/tests/relational/test_independent_strategy.py
+++ b/tests/relational/test_independent_strategy.py
@@ -69,7 +69,7 @@ def test_table_generation_readiness(ecom):
 
 def test_generation_job_requests_num_records(pets):
     strategy = IndependentStrategy()
-    job = strategy.get_generation_job("pets", pets, 2.0, {}, Path("/working"), [])
+    job = strategy.get_generation_job("pets", pets, 2.0, {}, Path("/working"))
 
     assert job == {"params": {"num_records": 10}}
 

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -89,7 +89,6 @@ def make_backup(
             model_ids={
                 table: mock.model_id for table, mock in synthetics_models.items()
             },
-            training_columns={table: ["col1", "col2"] for table in synthetics_models},
             lost_contact=[],
         )
     if len(synthetics_record_handlers) > 0:

--- a/tests/relational/test_multi_table_restore.py
+++ b/tests/relational/test_multi_table_restore.py
@@ -97,7 +97,6 @@ def make_backup(
             preserved=[],
             record_size_ratio=1.0,
             lost_contact=[],
-            missing_model=[],
             record_handler_ids={
                 table: mock.record_id
                 for table, mock in synthetics_record_handlers.items()
@@ -671,7 +670,6 @@ def test_restore_generate_in_progress(
         preserved=[],
         record_size_ratio=1.0,
         lost_contact=[],
-        missing_model=[],
         record_handlers=synthetics_record_handlers,
     )
     assert len(mt.synthetic_output_tables) == 0

--- a/tests/relational/test_synthetics_run_task.py
+++ b/tests/relational/test_synthetics_run_task.py
@@ -55,10 +55,6 @@ def make_task(
             record_size_ratio=1.0,
         ),
         synthetics_train=SyntheticsTrain(
-            training_columns={
-                table: list(rel_data.get_table_data(table).columns)
-                for table in rel_data.list_all_tables()
-            },
             models={
                 table: Mock(create_record_handler=Mock())
                 for table in rel_data.list_all_tables()

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -1,0 +1,92 @@
+import tempfile
+from unittest.mock import ANY, patch
+
+import pytest
+
+from gretel_trainer.relational.core import MultiTableException
+from gretel_trainer.relational.multi_table import MultiTable
+
+
+# The assertions in this file are concerned with setting up the transforms train
+# workflow state properly, and stop short of kicking off the task.
+@pytest.fixture(autouse=True)
+def run_task():
+    with patch("gretel_trainer.relational.multi_table.run_task"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def backup():
+    with patch.object(MultiTable, "_backup", return_value=None):
+        yield
+
+
+@pytest.fixture()
+def tmpdir(project):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project.name = tmpdir
+        yield tmpdir
+
+
+def test_train_synthetics_defaults_to_training_all_tables(ecom, tmpdir):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics()
+
+    assert set(mt._synthetics_train.models.keys()) == set(ecom.list_all_tables())
+
+
+def test_train_synthetics_only_includes_specified_tables(ecom, tmpdir, project):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics(only=["users"])
+
+    assert set(mt._synthetics_train.models.keys()) == {"users"}
+    project.create_model_obj.assert_called_with(
+        model_config=ANY,  # a tailored transforms config, in dict form
+        data_source=f"{tmpdir}/synthetics_train_users.csv",
+    )
+
+
+def test_train_synthetics_ignore_excludes_specified_tables(ecom, tmpdir):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics(ignore=["distribution_center", "products"])
+
+    assert set(mt._synthetics_train.models.keys()) == {
+        "events",
+        "users",
+        "order_items",
+        "inventory_items",
+    }
+
+
+def test_train_synthetics_exits_early_if_unrecognized_tables(ecom, tmpdir, project):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    with pytest.raises(MultiTableException):
+        mt.train_synthetics(ignore=["nonsense"])
+
+    assert len(mt._synthetics_train.models) == 0
+    project.create_model_obj.assert_not_called()
+
+
+def test_train_synthetics_multiple_calls_additive(ecom, tmpdir):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics(only=["products"])
+    mt.train_synthetics(only=["users"])
+
+    # We do not lose the first table model
+    assert set(mt._synthetics_train.models.keys()) == {"products", "users"}
+
+
+def test_train_synthetics_multiple_calls_overwrite(ecom, tmpdir, project):
+    project.create_model_obj.return_value = "m1"
+
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics(only=["products"])
+
+    assert mt._synthetics_train.models["products"] == "m1"
+
+    project.reset_mock()
+    project.create_model_obj.return_value = "m2"
+
+    # calling a second time will create a new model for the table that overwrites the original
+    mt.train_synthetics(only=["products"])
+    assert mt._synthetics_train.models["products"] == "m2"

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -7,7 +7,7 @@ from gretel_trainer.relational.core import MultiTableException
 from gretel_trainer.relational.multi_table import MultiTable
 
 
-# The assertions in this file are concerned with setting up the transforms train
+# The assertions in this file are concerned with setting up the synthetics train
 # workflow state properly, and stop short of kicking off the task.
 @pytest.fixture(autouse=True)
 def run_task():
@@ -41,7 +41,7 @@ def test_train_synthetics_only_includes_specified_tables(ecom, tmpdir, project):
 
     assert set(mt._synthetics_train.models.keys()) == {"users"}
     project.create_model_obj.assert_called_with(
-        model_config=ANY,  # a tailored transforms config, in dict form
+        model_config=ANY,  # a tailored synthetics config, in dict form
         data_source=f"{tmpdir}/synthetics_train_users.csv",
     )
 

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -90,3 +90,18 @@ def test_train_synthetics_multiple_calls_overwrite(ecom, tmpdir, project):
     # calling a second time will create a new model for the table that overwrites the original
     mt.train_synthetics(only=["products"])
     assert mt._synthetics_train.models["products"] == "m2"
+
+
+def test_train_synthetics_after_deleting_models(ecom, tmpdir):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_synthetics(only=["products"])
+    mt.delete_models("synthetics")
+    mt.train_synthetics(only=["users"])
+
+    assert set(mt._synthetics_train.models.keys()) == {"users"}
+
+    # You can scope deletion to a subset of tables
+    mt.train_synthetics(only=["users", "products"])
+    assert set(mt._synthetics_train.models.keys()) == {"users", "products"}
+    mt.delete_models("synthetics", ignore=["products"])
+    assert set(mt._synthetics_train.models.keys()) == {"products"}

--- a/tests/relational/test_train_transforms.py
+++ b/tests/relational/test_train_transforms.py
@@ -96,6 +96,15 @@ def test_train_transforms_multiple_calls_overwrite(ecom, tmpdir, project):
     assert mt._transforms_train.models["products"] == "m2"
 
 
+def test_train_transforms_after_deleting_models(ecom, tmpdir):
+    mt = MultiTable(ecom, project_display_name=tmpdir)
+    mt.train_transforms("transform/default", only=["products"])
+    mt.delete_models("transforms")
+    mt.train_transforms("transform/default", only=["users"])
+
+    assert set(mt._transforms_train.models.keys()) == {"users"}
+
+
 # The public method under test here is deprecated
 def test_train_transform_models(ecom, tmpdir):
     mt = MultiTable(ecom, project_display_name=tmpdir)


### PR DESCRIPTION
### Main user-facing change

The `train` method is deprecated in favor of the new `train_synthetics` method. The latter accepts optional `only | ignore` lists to limit which tables are trained—the idea here is that if some table contains static reference data that you don't want synthesized, you can omit it from the synthetics workflow entirely.

The main reason for introducing this as a new method instead of optional arguments to the existing method is that the original `train` method resets the synthetic train state when called a second time. That felt like behavior a user _might_ rely on, so I figured it'd be safest to leave it alone and introduce a new method (which, FYI, works "additively"—see [this conversation](https://github.com/gretelai/trainer/pull/109#discussion_r1198129227) discussing it in the context of Transforms). I also think the original method name is too generic and it's nicer to specify "synthetics" in the method name given what all Relational can do.

Note: previously we let users skip table synthesis at `generate` time via the `preserve: list[str]` argument, but of course that method is called _after_ `train`/`train_synthetics` so we would have unnecessarily trained models for the preserved tables. The `preserve` argument still exists on `generate` and currently is _not_ marked for deprecation—we want to see if any customers have a use case for it (e.g. I have 10 tables, I know 2 will never be synthesized so I omit them from training, later during generation there is one more table I want to preserve with source data instead of synthesizing. TBD.)

### Delete models method

The same [conversation](https://github.com/gretelai/trainer/pull/109#discussion_r1198129227) with @pimlock on #109 got me thinking that we should have a `delete_models` method—it seems like a useful thing to have alongside the `only | ignore` params. It was a pretty straightforward thing to add, but we could also skip it / remove it from this PR. @gracecvking any thoughts?

### Internal improvements

- Previously we had been keeping track of which columns were used in model training so that the ancestral strategy could be sure not to include those columns in seed data. In #101 we moved the logic of which columns can be used in seeding to the core `RelationalData` class. Here, I realized since that info is calculated and cached there, we don't need to carry it in the MultiTable state and backups—we can just ask for it again—so `training_columns` is removed from several places.
- Previously we had a dedicated field related to synthetics generate state called `missing_model` for tables that didn't train successfully. However, since we now allow users to omit tables from training, we can no longer say "if we can't get a completed model, treat it as failed"—we now need to know if the table attempted training unsuccessfully, or was deliberately omitted. Fortunately, like above, we can calculate this from other data in state, so `missing_model` is dropped.
- We now create and upload the training data archive file _before_ submitting and waiting for the model training jobs