### PR TITLE
Reduce unnecessary JSON parsing

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -16,6 +16,7 @@ from gretel_trainer.relational.json import (
     IngestResponseT,
     InventedTableMetadata,
     RelationalJson,
+    get_json_columns,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,8 +130,12 @@ class RelationalData:
         the table includes nested JSON data.
         """
         primary_key = self._format_key_column(primary_key)
-        rj_ingest = RelationalJson.ingest(name, primary_key, data)
-        if rj_ingest is not None:
+        json_cols = get_json_columns(data)
+        if (
+            len(json_cols) > 0
+            and (rj_ingest := RelationalJson.ingest(name, primary_key, data, json_cols))
+            is not None
+        ):
             self._add_rel_json_and_tables(name, rj_ingest)
         else:
             self._add_single_table(name=name, primary_key=primary_key, data=data)

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -8,6 +8,7 @@ from gretel_trainer.relational.core import (
     RelationalData,
     Scope,
 )
+from gretel_trainer.relational.json import get_json_columns
 
 
 @pytest.fixture
@@ -22,6 +23,13 @@ def bball():
     rel_data.add_table(name="bball", primary_key=None, data=bball_df)
 
     return rel_data
+
+
+def test_list_json_cols(documents, bball):
+    assert get_json_columns(documents.get_table_data("users")) == []
+    assert get_json_columns(documents.get_table_data("purchases")) == ["data"]
+
+    assert set(get_json_columns(bball.get_table_data("bball"))) == {"draft", "teams"}
 
 
 def test_json_columns_produce_invented_flattened_tables(documents):


### PR DESCRIPTION
I noticed during an end-to-end test of a large set of tables that the initial check-for-JSON-and-normalize-it work that happens when we call `add_table` was taking a long time, even though none of the columns contained JSON data! The changes here speed up the entire process:
- Only operate on columns with dtype "object" (we can confidently ignore int, float, etc. columns)
- Before kicking off the full json normalization function, preview the first 5 not-null values in each object-dtype column in the dataframe...
  - If none of these contain JSON, don't bother executing json normalization at all
  - If any do contain JSON, pass those column names in to the "initial round" of `_normalize_json` to further reduce the amount of parsing necessary (in addition skipping non-object-dtype columns, we'd also skip columns that we just determined contain "non-JSON strings"). Subsequent invocations of `_normalize_json` (as we descend levels of nesting) do not pass in an explicit set of columns

Using 5 records for the preview/check was totally arbitrarily; I'm open to including more or fewer records if anyone has an opinion / good reason.