### PR TITLE
Fix bug related to empty normalized tables

### DIFF
--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -10,7 +10,7 @@ from gretel_trainer.relational.core import ForeignKey, RelationalData
 @dataclass
 class BackupRelationalDataTable:
     primary_key: list[str]
-    invented_table_metadata: Optional[dict[str, str]] = None
+    invented_table_metadata: Optional[dict] = None
 
 
 @dataclass

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -36,7 +36,6 @@ class BackupRelationalJson:
     original_primary_key: list[str]
     original_columns: list[str]
     table_name_mappings: dict[str, str]
-    invented_table_names: list[str]
 
 
 @dataclass
@@ -71,7 +70,6 @@ class BackupRelationalData:
                 original_primary_key=rel_json.original_primary_key,
                 original_columns=rel_json.original_columns,
                 table_name_mappings=rel_json.table_name_mappings,
-                invented_table_names=rel_json.table_names,
             )
         return BackupRelationalData(
             tables=tables, foreign_keys=foreign_keys, relational_jsons=relational_jsons

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -10,7 +10,7 @@ from gretel_trainer.relational.core import ForeignKey, RelationalData
 @dataclass
 class BackupRelationalDataTable:
     primary_key: list[str]
-    invented_table_metadata: Optional[dict] = None
+    invented_table_metadata: Optional[dict[str, Any]] = None
 
 
 @dataclass

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import suppress
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
@@ -238,7 +237,7 @@ class RelationalData:
         )
 
         for invented_table_name in rel_json.table_names:
-            with suppress(KeyError):
+            if invented_table_name in self.graph.nodes:
                 self.graph.remove_node(invented_table_name)
         del self.relational_jsons[table]
 
@@ -472,7 +471,9 @@ class RelationalData:
         If the provided table does not exist, returns empty list.
         """
         if (rel_json := self.relational_jsons.get(table)) is not None:
-            return rel_json.table_names
+            # Exclude tables that JSON is tracking for denormalization but that weren't added to the graph
+            # (i.e. because they were empty)
+            return [t for t in rel_json.table_names if t in self.graph.nodes]
         elif table not in self.list_all_tables(Scope.ALL):
             return []
         else:

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -429,34 +429,47 @@ class RelationalData:
                 self._clear_safe_ancestral_seed_columns(table)
 
     def list_all_tables(self, scope: Scope = Scope.MODELABLE) -> list[str]:
-        modelable_nodes = self.graph.nodes
+        """
+        Returns a list of table names belonging to the provided Scope.
+        See Scope enum documentation for details.
+        By default, returns tables that can be submitted as jobs to Gretel
+        (i.e. that are MODELABLE).
+        """
+        graph_nodes = list(self.graph.nodes)
 
         json_source_tables = [
             rel_json.original_table_name
             for _, rel_json in self.relational_jsons.items()
         ]
 
+        all_tables = graph_nodes + json_source_tables
+
+        modelable_tables = []
+        evaluatable_tables = []
+        invented_tables: list[str] = []
+
+        for n in graph_nodes:
+            meta = self.graph.nodes[n]["metadata"]
+            if (invented_meta := meta.invented_table_metadata) is not None:
+                invented_tables.append(n)
+                if invented_meta.invented_root_table_name == n:
+                    evaluatable_tables.append(n)
+                if not invented_meta.empty:
+                    modelable_tables.append(n)
+            else:
+                modelable_tables.append(n)
+                evaluatable_tables.append(n)
+
         if scope == Scope.MODELABLE:
-            return list(modelable_nodes)
+            return modelable_tables
         elif scope == Scope.EVALUATABLE:
-            e = []
-            for n in modelable_nodes:
-                meta = self.graph.nodes[n]["metadata"]
-                if (
-                    meta.invented_table_metadata is None
-                    or meta.invented_table_metadata.invented_root_table_name == n
-                ):
-                    e.append(n)
-            return e
+            return evaluatable_tables
         elif scope == Scope.INVENTED:
-            return [n for n in modelable_nodes if self._is_invented(n)]
+            return invented_tables
         elif scope == Scope.ALL:
-            return list(modelable_nodes) + json_source_tables
+            return all_tables
         elif scope == Scope.PUBLIC:
-            non_invented_nodes = [
-                n for n in modelable_nodes if not self._is_invented(n)
-            ]
-            return json_source_tables + non_invented_nodes
+            return [t for t in all_tables if t not in invented_tables]
 
     def _is_invented(self, table: str) -> bool:
         return (
@@ -466,18 +479,20 @@ class RelationalData:
 
     def get_modelable_table_names(self, table: str) -> list[str]:
         """Returns a list of MODELABLE table names connected to the provided table.
-        If the provided table is already modelable, returns [table].
-        If the provided table is not modelable (e.g. source with JSON), returns tables invented from that source.
-        If the provided table does not exist, returns empty list.
+        If the provided table is the source of invented tables, returns the modelable invented tables created from it.
+        If the provided table is itself modelable, returns that table name back.
+        Otherwise returns an empty list.
         """
         if (rel_json := self.relational_jsons.get(table)) is not None:
-            # Exclude tables that JSON is tracking for denormalization but that weren't added to the graph
-            # (i.e. because they were empty)
-            return [t for t in rel_json.table_names if t in self.graph.nodes]
-        elif table not in self.list_all_tables(Scope.ALL):
-            return []
-        else:
+            return [
+                t
+                for t in rel_json.table_names
+                if t in self.list_all_tables(Scope.MODELABLE)
+            ]
+        elif table in self.list_all_tables(Scope.MODELABLE):
             return [table]
+        else:
+            return []
 
     def get_public_name(self, table: str) -> Optional[str]:
         if table in self.relational_jsons:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -154,6 +154,7 @@ class MultiTable:
                 invented_table_metadata = InventedTableMetadata(
                     invented_root_table_name=imeta["invented_root_table_name"],
                     original_table_name=imeta["original_table_name"],
+                    empty=imeta["empty"],
                 )
             self.relational_data._add_single_table(
                 name=table_name,

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -43,6 +43,7 @@ def test_backup_relational_data_with_json(documents):
                 invented_table_metadata={
                     "invented_root_table_name": "purchases-sfx",
                     "original_table_name": "purchases",
+                    "empty": False,
                 },
             ),
             "purchases-data-years-sfx": BackupRelationalDataTable(
@@ -50,6 +51,7 @@ def test_backup_relational_data_with_json(documents):
                 invented_table_metadata={
                     "invented_root_table_name": "purchases-sfx",
                     "original_table_name": "purchases",
+                    "empty": False,
                 },
             ),
             "payments": BackupRelationalDataTable(primary_key=["id"]),

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -12,7 +12,6 @@ from gretel_trainer.relational.backup import (
     BackupSyntheticsTrain,
     BackupTransformsTrain,
 )
-from gretel_trainer.relational.json import InventedTableMetadata
 
 
 def test_backup_relational_data(trips):
@@ -84,7 +83,6 @@ def test_backup_relational_data_with_json(documents):
                     "purchases": "purchases-sfx",
                     "purchases^data>years": "purchases-data-years-sfx",
                 },
-                invented_table_names=["purchases-sfx", "purchases-data-years-sfx"],
             ),
         },
     )

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -148,12 +148,13 @@ def test_get_modelable_names_ignores_empty_mapped_tables(bball):
         "bball-suspensions-sfx",
     }
 
-    # ...BUT clients of RelationalData only care about invented tables that were added
-    # to the graph (i.e. that contain data), so that class does not expose the empty table.
+    # ...BUT clients of RelationalData only care about invented tables that can be modeled
+    # (i.e. that contain data), so that class does not expose the empty table.
     assert set(bball.get_modelable_table_names("bball")) == {
         "bball-sfx",
         "bball-teams-sfx",
     }
+    assert set(bball.list_all_tables()) == {"bball-sfx", "bball-teams-sfx"}
 
 
 def test_invented_json_column_names(documents, bball):


### PR DESCRIPTION
When parsing JSON, it's possible for all values to contain some empty list value—for example, in the unit tests `bball` fixture, each player has a `suspensions` key with empty list value. We want to be able to restore this field in the final denormalized/original-matching output data, but we **don't** want to submit an empty table for training.

We now include add empty invented tables to the graph (so we know where to put them back when denormalizing), but ensure they are not exposed to clients asking for MODELABLE tables.

As before this branch, we still do not support dataframes where _all columns_ contain JSON lists. Fortunately, as the unit test changes demonstrate, these changes have the added benefit of detecting that sooner and avoiding ending up in a bad state when this edge case happens.