### PR TITLE
Adjust JSON log locations

### DIFF
--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -142,6 +142,9 @@ class RelationalData:
     ) -> Optional[IngestResponseT]:
         json_cols = get_json_columns(data)
         if len(json_cols) > 0:
+            logger.info(
+                f"Detected JSON data in table `{table}`. Running JSON normalization."
+            )
             return RelationalJson.ingest(table, primary_key, data, json_cols)
 
     def _add_rel_json_and_tables(self, table: str, rj_ingest: IngestResponseT) -> None:

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -174,14 +174,11 @@ class RelationalJson:
         df: pd.DataFrame,
         json_columns: Optional[list[str]] = None,
     ) -> Optional[IngestResponseT]:
-        logger.debug(f"Checking table `{table_name}` for JSON columns")
         tables = _normalize_json([(table_name, df.copy())], [], json_columns)
         # If we created additional tables (from JSON lists) or added columns (from JSON dicts)
         if len(tables) > 1 or len(tables[0][1].columns) > len(df.columns):
             mappings = {name: sanitize_str(name) for name, _ in tables}
-            logger.info(
-                f"Found JSON data in table `{table_name}`, transformed into {len(mappings)} tables for modeling."
-            )
+            logger.info(f"Transformed JSON into {len(mappings)} tables for modeling.")
             logger.debug(f"Invented table names: {list(mappings.values())}")
             rel_json = RelationalJson(
                 original_table_name=table_name,


### PR DESCRIPTION
Just a small location change on these log messages. I think this will be more useful because the user will get a message after JSON is detected (quickly, using the preview) but **before** running the full normalization (which may take a while), so they should better understand why adding a particular table is taking a long time.