### PR TITLE
Write and drop

### DIFF
--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -724,15 +724,12 @@ class MultiTable:
         to the working directory. Returns a dict with table names as keys and Paths
         to the CSVs as values.
         """
-        training_data = self._strategy.prepare_training_data(
-            self.relational_data, tables
-        )
-        training_paths = {}
+        training_paths = {
+            table: self._working_dir / f"synthetics_train_{table}.csv"
+            for table in tables
+        }
 
-        for table_name in tables:
-            training_path = self._working_dir / f"synthetics_train_{table_name}.csv"
-            training_data[table_name].to_csv(training_path, index=False)
-            training_paths[table_name] = training_path
+        self._strategy.prepare_training_data(self.relational_data, training_paths)
 
         return training_paths
 

--- a/src/gretel_trainer/relational/strategies/ancestral.py
+++ b/src/gretel_trainer/relational/strategies/ancestral.py
@@ -33,19 +33,19 @@ class AncestralStrategy:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
-        self, rel_data: RelationalData, tables: list[str]
-    ) -> dict[str, pd.DataFrame]:
+        self, rel_data: RelationalData, table_paths: dict[str, Path]
+    ) -> dict[str, Path]:
         """
-        Returns tables with:
+        Writes tables' training data to provided paths.
+        Training data has:
         - all safe-for-seed ancestor fields added
         - columns in multigenerational format
         - all keys translated to contiguous integers
         - artificial min/max seed records added
         """
         all_tables = rel_data.list_all_tables()
-        omitted_tables = [t for t in all_tables if t not in tables]
+        omitted_tables = [t for t in all_tables if t not in table_paths]
         altered_tableset = {}
-        training_data = {}
 
         # Create a new table set identical to source data
         for table_name in all_tables:
@@ -62,16 +62,16 @@ class AncestralStrategy:
         )
 
         # Collect all data in multigenerational format
-        for table_name in tables:
+        for table, path in table_paths.items():
             data = ancestry.get_table_data_with_ancestors(
                 rel_data=rel_data,
-                table=table_name,
+                table=table,
                 tableset=altered_tableset,
                 ancestral_seeding=True,
             )
-            training_data[table_name] = data
+            data.to_csv(path, index=False)
 
-        return training_data
+        return table_paths
 
     def tables_to_retrain(
         self, tables: list[str], rel_data: RelationalData

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -34,25 +34,24 @@ class IndependentStrategy:
         return common.label_encode_keys(rel_data, tables)
 
     def prepare_training_data(
-        self, rel_data: RelationalData, tables: list[str]
-    ) -> dict[str, pd.DataFrame]:
+        self, rel_data: RelationalData, table_paths: dict[str, Path]
+    ) -> dict[str, Path]:
         """
-        Returns source tables with primary and foreign keys removed
+        Writes tables' training data to provided paths.
+        Training data has primary and foreign key columns removed.
         """
-        training_data = {}
-
-        for table_name in tables:
+        for table, path in table_paths.items():
             columns_to_drop = []
-            columns_to_drop.extend(rel_data.get_primary_key(table_name))
-            for foreign_key in rel_data.get_foreign_keys(table_name):
+            columns_to_drop.extend(rel_data.get_primary_key(table))
+            for foreign_key in rel_data.get_foreign_keys(table):
                 columns_to_drop.extend(foreign_key.columns)
 
-            data = rel_data.get_table_data(table_name)
+            data = rel_data.get_table_data(table)
             data = data.drop(columns=columns_to_drop)
 
-            training_data[table_name] = data
+            data.to_csv(path, index=False)
 
-        return training_data
+        return table_paths
 
     def tables_to_retrain(
         self, tables: list[str], rel_data: RelationalData

--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -41,15 +41,17 @@ class IndependentStrategy:
         Training data has primary and foreign key columns removed.
         """
         for table, path in table_paths.items():
-            columns_to_drop = []
-            columns_to_drop.extend(rel_data.get_primary_key(table))
+            columns_to_drop = set()
+            columns_to_drop.update(rel_data.get_primary_key(table))
             for foreign_key in rel_data.get_foreign_keys(table):
-                columns_to_drop.extend(foreign_key.columns)
+                columns_to_drop.update(foreign_key.columns)
 
-            data = rel_data.get_table_data(table)
-            data = data.drop(columns=columns_to_drop)
+            all_columns = rel_data.get_table_columns(table)
+            use_columns = all_columns - columns_to_drop
 
-            data.to_csv(path, index=False)
+            rel_data.get_table_data(table, usecols=use_columns).to_csv(
+                path, index=False
+            )
 
         return table_paths
 


### PR DESCRIPTION
Currently, the preprocessing in synthetics training creates a training DF for each table, keeps each of those in a dictionary, and passes the dictionary to the next method which writes each to a CSV and submits a model.

With this change, each training DF is written to CSV as soon as it is created, so we don't have to hold on to more than one at a time.

There's also a small change to the independent strategy specifically: instead of asking for the whole source dataframe and then dropping columns, we only ask for the columns we intend to keep. This doesn't make too big a difference now (since the whole source DF is already in memory in the graph), but we anticipate eventually storing source data on disk and loading in the data when needed, and presumably at that point this will provide some greater benefit.