### PR TITLE
Bettertar

### DIFF
--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -19,7 +19,11 @@ from gretel_client.projects import Project, create_project, get_project
 from gretel_client.projects.jobs import ACTIVE_STATES, END_STATES, Status
 from gretel_client.projects.records import RecordHandler
 
-from gretel_trainer.relational.artifacts import ArtifactCollection, add_to_tar
+from gretel_trainer.relational.artifacts import (
+    ArtifactCollection,
+    archive_items,
+    archive_nested_dir,
+)
 from gretel_trainer.relational.backup import (
     Backup,
     BackupClassify,
@@ -546,8 +550,7 @@ class MultiTable:
         run_task(task, self._extended_sdk)
 
         archive_path = self._working_dir / "classify_outputs.tar.gz"
-        for arcname, path in task.result_filepaths.items():
-            add_to_tar(archive_path, path, arcname)
+        archive_items(archive_path, task.result_filepaths)
         self._artifact_collection.upload_classify_outputs_archive(
             self._project, str(archive_path)
         )
@@ -689,11 +692,16 @@ class MultiTable:
             out_path = run_dir / filename
             df.to_csv(out_path, index=False)
 
-        archive_path = self._working_dir / "transforms_outputs.tar.gz"
-        add_to_tar(archive_path, run_dir, identifier)
+        all_runs_archive_path = self._working_dir / "transforms_outputs.tar.gz"
+
+        archive_nested_dir(
+            targz=all_runs_archive_path,
+            directory=run_dir,
+            name=identifier,
+        )
 
         self._artifact_collection.upload_transforms_outputs_archive(
-            self._project, str(archive_path)
+            self._project, str(all_runs_archive_path)
         )
         self._backup()
         self.transform_output_tables = reshaped_tables
@@ -740,8 +748,7 @@ class MultiTable:
             self._synthetics_train.models[table_name] = model
 
         archive_path = self._working_dir / "synthetics_training.tar.gz"
-        for table_name, csv_path in training_paths.items():
-            add_to_tar(archive_path, csv_path, csv_path.name)
+        archive_items(archive_path, list(training_paths.values()))
         self._artifact_collection.upload_synthetics_training_archive(
             self._project, str(archive_path)
         )
@@ -993,11 +1000,16 @@ class MultiTable:
             target_dir=run_dir,
         )
 
-        archive_path = self._working_dir / "synthetics_outputs.tar.gz"
-        add_to_tar(archive_path, run_dir, self._synthetics_run.identifier)
+        all_runs_archive_path = self._working_dir / "synthetics_outputs.tar.gz"
+
+        archive_nested_dir(
+            targz=all_runs_archive_path,
+            directory=run_dir,
+            name=self._synthetics_run.identifier,
+        )
 
         self._artifact_collection.upload_synthetics_outputs_archive(
-            self._project, str(archive_path)
+            self._project, str(all_runs_archive_path)
         )
         self.synthetic_output_tables = reshaped_tables
         self._backup()

--- a/src/gretel_trainer/relational/tasks/classify.py
+++ b/src/gretel_trainer/relational/tasks/classify.py
@@ -30,7 +30,7 @@ class ClassifyTask:
         self.failed_models = []
         self.completed_record_handlers = []
         self.failed_record_handlers = []
-        self.result_filepaths: dict[str, Path] = {}
+        self.result_filepaths: list[Path] = []
 
     def action(self, job: Job) -> str:
         if self.all_rows:
@@ -153,4 +153,4 @@ class ClassifyTask:
             job.get_artifact_link(artifact_name), "rb"
         ) as src, smart_open.open(str(destpath), "wb") as dest:
             shutil.copyfileobj(src, dest)
-        self.result_filepaths[filename] = destpath
+        self.result_filepaths.append(destpath)

--- a/tests/relational/test_artifacts.py
+++ b/tests/relational/test_artifacts.py
@@ -1,47 +1,78 @@
+import os
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
-from gretel_trainer.relational.artifacts import ArtifactCollection, add_to_tar
+import pytest
+
+from gretel_trainer.relational.artifacts import (
+    ArtifactCollection,
+    archive_items,
+    archive_nested_dir,
+)
 
 
-def test_makes_new_archive():
-    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1:
-        archive_path = Path(tmpdir) / "archive.tar.gz"
-        add_to_tar(archive_path, Path(tf1.name), "tf1")
-
-        with tarfile.open(archive_path, "r:gz") as tar:
-            assert len(tar.getnames()) == 1
+@pytest.fixture()
+def out_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
 
 
-def test_appends_to_existing_archive():
-    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
-        archive_path = Path(tmpdir) / "archive.tar.gz"
-        add_to_tar(archive_path, Path(tf1.name), "tf1")
-        add_to_tar(archive_path, Path(tf2.name), "tf2")
-
-        with tarfile.open(archive_path, "r:gz") as tar:
-            assert len(tar.getnames()) == 2
+@pytest.fixture()
+def tempfiles():
+    with tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
+        yield [Path(tf1.name), Path(tf2.name)]
 
 
-def test_overwrites_existing_file_in_archive():
-    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1:
-        archive_path = Path(tmpdir) / "archive.tar.gz"
-        add_to_tar(archive_path, Path(tf1.name), "tf1")
-        add_to_tar(archive_path, Path(tf1.name), "tf1")
+def test_archiving_items(out_dir, tempfiles):
+    tgz = out_dir / "out.tar.gz"
+    archive_items(tgz, tempfiles)
+    print(tgz.exists())
 
-        with tarfile.open(archive_path, "r:gz") as tar:
-            assert len(tar.getnames()) == 1
+    with tarfile.open(tgz, "r:gz") as tar:
+        assert set(tar.getnames()) == {
+            ".",
+            f"./{tempfiles[0].name}",
+            f"./{tempfiles[1].name}",
+        }
 
-    # Overwrite is based on provided arcname, not file contents
-    with tempfile.TemporaryDirectory() as tmpdir, tempfile.NamedTemporaryFile() as tf1, tempfile.NamedTemporaryFile() as tf2:
-        archive_path = Path(tmpdir) / "archive.tar.gz"
-        add_to_tar(archive_path, Path(tf1.name), "name")
-        add_to_tar(archive_path, Path(tf2.name), "name")
 
-        with tarfile.open(archive_path, "r:gz") as tar:
-            assert len(tar.getnames()) == 1
+def test_archive_nested_dir(out_dir, tempfiles):
+    tgz = out_dir / "out.tar.gz"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_to_archive = Path(tmpdir)
+        for tfile in tempfiles:
+            shutil.copy(tfile, dir_to_archive)
+
+        # When the provided targz path does not yet exist, creates a new archive with a nested archive
+        archive_nested_dir(tgz, dir_to_archive, "id1")
+
+        with tarfile.open(tgz, "r:gz") as tar:
+            assert set(tar.getnames()) == {".", "./id1.tar.gz"}
+
+            with tempfile.TemporaryDirectory() as td:
+                tar.extract("./id1.tar.gz", td)
+                with tarfile.open(f"{td}/id1.tar.gz", "r:gz") as nested:
+                    assert set(nested.getnames()) == {
+                        ".",
+                        f"./{tempfiles[0].name}",
+                        f"./{tempfiles[1].name}",
+                    }
+
+        # Later, new directories can be added to the existing archive
+        archive_nested_dir(tgz, dir_to_archive, "id2")
+
+        with tarfile.open(tgz, "r:gz") as tar:
+            assert set(tar.getnames()) == {".", "./id1.tar.gz", "./id2.tar.gz"}
+
+        # In the case of a name conflict, the added dir overwrites/replaces an existing dir
+        archive_nested_dir(tgz, dir_to_archive, "id2")
+
+        with tarfile.open(tgz, "r:gz") as tar:
+            assert set(tar.getnames()) == {".", "./id1.tar.gz", "./id2.tar.gz"}
 
 
 def test_uploads_path_to_project_and_stores_artifact_key():


### PR DESCRIPTION
#### User-facing change (minor)
The outputs archives for transforms and synthetics (which are singleton objects we treat sort of like "buckets" holding all the outputs from multiple `run_transforms` / `generate` calls) are now "archives of archives" instead of archives of files organized in subdirectories:
```
# prev

synthetics_outputs.tar.gz
- t1/
  - synth_customer.csv
  - synth_location.csv
  - reports, etc.
- t2/
  - synth_customer.csv
  - synth_location.csv
  - reports, etc.
```
```
# new

synthetics_outputs.tar.gz
- t1.tar.gz
- t2.tar.gz
```
(where "t1" and "t2" are run identifiers—can be user supplied but default to current timestamp)

#### Performance details
The previous approach to creating regular archive files (everything used a single `add_to_tar` function) was woefully inefficient. In the case of archives that are only made once with no nesting (e.g. source data, synthetics training datasets) we now have `archive_items`. Using the same set of non-trivial-sized tables mentioned in #117 :
```python
from pathlib import Path

# old
tarpath = Path("./addtotar.tar.gz")
for f in files:
    fpath = Path(f)
    add_to_tar(tarpath, fpath, fpath.name)

# new
archive_items(Path("./archiveitems.tar.gz"), files)
```
- Old: 20m 25.6s :turtle:
- New: 4m 41.5s :rocket:

In the case of the "bucket archives" with results from multiple runs described above (run transforms multiple times, generate multiple times), the new `archive_nested_dir` is significantly better as more and more runs are added:
```python
# contains 6 CSV files with sizes from 39–225 MB
test_dir = "test_dir"

# old
archive_of_subdirs = Path("archive_of_subdirs.tar.gz")
add_to_tar(archive_of_subdirs, test_dir, "t1")
add_to_tar(archive_of_subdirs, test_dir, "t2")
add_to_tar(archive_of_subdirs, test_dir, "t3")
add_to_tar(archive_of_subdirs, test_dir, "t4")


# new
archive_of_archives = Path("archive_of_archives.tar.gz")
archive_nested_dir(archive_of_archives, test_dir, "t1")
archive_nested_dir(archive_of_archives, test_dir, "t2")
archive_nested_dir(archive_of_archives, test_dir, "t3")
archive_nested_dir(archive_of_archives, test_dir, "t4")
```
Individual times for each operation:
- Old
  - 1m 7s
  - 2m 17s
  - 3m 27s
  - 4m 38s
- New
  - 1m 12s
  - 1m 18s
  - 1m 24s
  - 1m 30s