### PR TITLE
Custom synthetics configs

### DIFF
--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any
+from typing import Any, Optional
 
 from gretel_client.projects.models import read_model_config
 
@@ -8,6 +8,16 @@ from gretel_trainer.relational.core import (
     MultiTableException,
     RelationalData,
 )
+
+
+def get_model_key(config_dict: dict[str, Any]) -> Optional[str]:
+    try:
+        models = config_dict["models"]
+        assert isinstance(models, list)
+        assert isinstance(models[0], dict)
+        return list(models[0])[0]
+    except (AssertionError, IndexError, KeyError):
+        return None
 
 
 def _ingest(config: GretelModelConfig) -> dict[str, Any]:

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import Any, Optional
 
+from gretel_client.projects.exceptions import ModelConfigError
 from gretel_client.projects.models import read_model_config
 
 from gretel_trainer.relational.core import (
@@ -21,7 +22,10 @@ def get_model_key(config_dict: dict[str, Any]) -> Optional[str]:
 
 
 def ingest(config: GretelModelConfig) -> dict[str, Any]:
-    return read_model_config(deepcopy(config))
+    try:
+        return read_model_config(deepcopy(config))
+    except ModelConfigError as e:
+        raise MultiTableException("Invalid config") from e
 
 
 def _model_name(workflow: str, table: str) -> str:

--- a/src/gretel_trainer/relational/model_config.py
+++ b/src/gretel_trainer/relational/model_config.py
@@ -20,7 +20,7 @@ def get_model_key(config_dict: dict[str, Any]) -> Optional[str]:
         return None
 
 
-def _ingest(config: GretelModelConfig) -> dict[str, Any]:
+def ingest(config: GretelModelConfig) -> dict[str, Any]:
     return read_model_config(deepcopy(config))
 
 
@@ -30,19 +30,19 @@ def _model_name(workflow: str, table: str) -> str:
 
 
 def make_classify_config(table: str, config: GretelModelConfig) -> dict[str, Any]:
-    tailored_config = _ingest(config)
+    tailored_config = ingest(config)
     tailored_config["name"] = _model_name("classify", table)
     return tailored_config
 
 
 def make_evaluate_config(table: str) -> dict[str, Any]:
-    tailored_config = _ingest("evaluate/default")
+    tailored_config = ingest("evaluate/default")
     tailored_config["name"] = _model_name("evaluate", table)
     return tailored_config
 
 
 def make_synthetics_config(table: str, config: GretelModelConfig) -> dict[str, Any]:
-    tailored_config = _ingest(config)
+    tailored_config = ingest(config)
     tailored_config["name"] = _model_name("synthetics", table)
     return tailored_config
 
@@ -50,7 +50,7 @@ def make_synthetics_config(table: str, config: GretelModelConfig) -> dict[str, A
 def make_transform_config(
     rel_data: RelationalData, table: str, config: GretelModelConfig
 ) -> dict[str, Any]:
-    tailored_config = _ingest(config)
+    tailored_config = ingest(config)
     tailored_config["name"] = _model_name("transforms", table)
 
     key_columns = rel_data.get_all_key_columns(table)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -814,7 +814,7 @@ class MultiTable:
         self,
         *,
         config: Optional[GretelModelConfig] = None,
-        table_configs: Optional[dict[str, GretelModelConfig]] = None,
+        table_specific_configs: Optional[dict[str, GretelModelConfig]] = None,
         only: Optional[set[str]] = None,
         ignore: Optional[set[str]] = None,
     ) -> None:
@@ -841,13 +841,13 @@ class MultiTable:
 
         # Translate any JSON-source tables in table_config_overrides to invented tables
         overrides = {}
-        for table, conf in (table_configs or {}).items():
+        for table, conf in (table_specific_configs or {}).items():
             m_names = self.relational_data.get_modelable_table_names(table)
             if len(m_names) == 0:
                 raise MultiTableException(f"Unrecognized table name: `{table}`")
             overrides.update({m: conf for m in m_names})
 
-        # Ensure compatibility between only/ignore and table_configs
+        # Ensure compatibility between only/ignore and table_specific_configs
         omitted_tables_with_overrides_specified = []
         for table in overrides:
             if table in omit_tables:

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -812,11 +812,11 @@ class MultiTable:
 
     def train_synthetics(
         self,
-        config: Optional[GretelModelConfig] = None,
         *,
+        config: Optional[GretelModelConfig] = None,
+        table_configs: Optional[dict[str, GretelModelConfig]] = None,
         only: Optional[set[str]] = None,
         ignore: Optional[set[str]] = None,
-        table_configs: Optional[dict[str, GretelModelConfig]] = None,
     ) -> None:
         """
         Train synthetic data models for the tables in the tableset,

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -719,6 +719,11 @@ class MultiTable:
     def _get_only_and_ignore(
         self, only: Optional[set[str]], ignore: Optional[set[str]]
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+        """
+        Accepts the `only` and `ignore` parameter values as provided by the user and:
+        - ensures both are not set (must provide one or the other, or neither)
+        - translates any JSON-source tables to the invented tables
+        """
         if only is not None and ignore is not None:
             raise MultiTableException("Cannot specify both `only` and `ignore`.")
 

--- a/tests/relational/test_model_config.py
+++ b/tests/relational/test_model_config.py
@@ -1,10 +1,23 @@
 from gretel_client.projects.models import read_model_config
 
 from gretel_trainer.relational.model_config import (
+    get_model_key,
     make_evaluate_config,
     make_synthetics_config,
     make_transform_config,
 )
+
+
+def test_get_model_key():
+    # Returns the model key when config is valid (at least as far as model key)
+    assert get_model_key({"models": [{"amplify": {}}]}) == "amplify"
+
+    # Returns None when given an invalid config
+    assert get_model_key({"foo": "bar"}) is None
+    assert get_model_key({"models": "wrong type"}) is None
+    assert get_model_key({"models": {"wrong": "type"}}) is None
+    assert get_model_key({"models": []}) is None
+    assert get_model_key({"models": ["wrong type"]}) is None
 
 
 def test_evaluate_config_prepends_workflow():

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -74,7 +74,7 @@ def test_train_synthetics_custom_config_for_all_tables(ecom, tmpdir, project):
     mt = MultiTable(ecom, project_display_name=tmpdir, gretel_model="amplify")
 
     # ...but provide an actgan config to train_synthetics.
-    mt.train_synthetics(mock_actgan_config)
+    mt.train_synthetics(config=mock_actgan_config)
 
     # The actgan config is used instead of amplify.
     project.create_model_obj.assert_called_with(
@@ -91,7 +91,9 @@ def test_train_synthetics_custom_configs_per_table(ecom, tmpdir, project):
     mt = MultiTable(ecom, project_display_name=tmpdir, gretel_model="amplify")
 
     # ...but provide an actgan config to use for tables PLUS a tabular-dp config for one specific table.
-    mt.train_synthetics(mock_actgan_config, table_configs={"events": mock_tabdp_config})
+    mt.train_synthetics(
+        config=mock_actgan_config, table_configs={"events": mock_tabdp_config}
+    )
 
     # The tabular-dp config is used for the singularly called-out table...
     project.create_model_obj.assert_any_call(
@@ -112,7 +114,7 @@ def test_train_synthetics_errors(ecom, tmpdir):
 
     # Invalid config
     with pytest.raises(MultiTableException):
-        mt.train_synthetics("nonsense")
+        mt.train_synthetics(config="nonsense")
 
     # Unrecognized table
     with pytest.raises(MultiTableException):
@@ -125,7 +127,7 @@ def test_train_synthetics_errors(ecom, tmpdir):
     # Config for unsupported model
     mt = MultiTable(ecom, project_display_name=tmpdir, strategy="ancestral")
     with pytest.raises(MultiTableException):
-        mt.train_synthetics(actgan_config)
+        mt.train_synthetics(config=actgan_config)
 
     # Table config for unsupported model
     mt = MultiTable(ecom, project_display_name=tmpdir, strategy="ancestral")

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -92,7 +92,7 @@ def test_train_synthetics_custom_configs_per_table(ecom, tmpdir, project):
 
     # ...but provide an actgan config to use for tables PLUS a tabular-dp config for one specific table.
     mt.train_synthetics(
-        config=mock_actgan_config, table_configs={"events": mock_tabdp_config}
+        config=mock_actgan_config, table_specific_configs={"events": mock_tabdp_config}
     )
 
     # The tabular-dp config is used for the singularly called-out table...
@@ -115,7 +115,7 @@ def test_train_synthetics_table_config_and_mt_init_default(ecom, tmpdir, project
     mt = MultiTable(ecom, project_display_name=tmpdir, gretel_model="amplify")
 
     # ...and provide a tabular-dp config for one specific table (but NOT a config).
-    mt.train_synthetics(table_configs={"events": mock_tabdp_config})
+    mt.train_synthetics(table_specific_configs={"events": mock_tabdp_config})
 
     # The tabular-dp config is used for the singularly called-out table...
     project.create_model_obj.assert_any_call(
@@ -150,11 +150,13 @@ def test_train_synthetics_errors(ecom, tmpdir):
 
     # Unrecognized table
     with pytest.raises(MultiTableException):
-        mt.train_synthetics(table_configs={"not-a-table": actgan_config})
+        mt.train_synthetics(table_specific_configs={"not-a-table": actgan_config})
 
     # Config provided for omitted table
     with pytest.raises(MultiTableException):
-        mt.train_synthetics(ignore={"users"}, table_configs={"users": actgan_config})
+        mt.train_synthetics(
+            ignore={"users"}, table_specific_configs={"users": actgan_config}
+        )
 
     # Config for unsupported model
     mt = MultiTable(ecom, project_display_name=tmpdir, strategy="ancestral")
@@ -164,7 +166,7 @@ def test_train_synthetics_errors(ecom, tmpdir):
     # Table config for unsupported model
     mt = MultiTable(ecom, project_display_name=tmpdir, strategy="ancestral")
     with pytest.raises(MultiTableException):
-        mt.train_synthetics(table_configs={"users": actgan_config})
+        mt.train_synthetics(table_specific_configs={"users": actgan_config})
 
 
 def test_train_synthetics_multiple_calls_additive(ecom, tmpdir):


### PR DESCRIPTION
With these changes, users are no longer limited to the synthetics blueprints configs and can provide fully customized model configs. You can supply one "main" config as well as table-specific configs if you want to get that granular:

```python
mt.train_synthetics(
    config=my_tabular_dp_config,
    table_specific_configs={"table_x": my_actgan_config},
)
```

~~Are these parameter values sufficiently clear? I didn't particularly like using the word "overrides" (e.g. `table_config_overrides`) because that feels to me like it'd be expecting "field-level" overrides on top of the `config` as a "base template", when in fact we are requiring _fully formed configs_ in both places.~~ EDIT: going with `table_specific_configs`

I recommend looking at the unit tests added to the diff for some behavior examples, but to call it out here in English: if you pass a `config` to the method call, it will overrule the blueprint set when you instantiate the MultiTable instance (the `gretel_model` attribute). We do still support `mt.train_synthetics()` for now, and in that case we continue to use that `gretel_model` blueprint config.

Looking ahead, we intend to deprecate `gretel_model` and require it be set when calling `train_synthetics` instead. We'll also move `strategy` as well. I'm not sure how soon we should add deprecation warnings; @gracecvking @mvansegbroeck any thoughts?