### PR TITLE
bq support plus better random and contiguous fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,32 +13,36 @@ postgres_extras = [
 snowflake_extras = [
     "snowflake-sqlalchemy",
 ]
-connectors_extras = mysql_extras + postgres_extras + snowflake_extras
+bigquery_extras = ["sqlalchemy-bigquery[bqstorage]"]
 
-setup(name="gretel-trainer",
-      use_scm_version=True,
-      setup_requires=["setuptools_scm"],
-      package_dir={'': 'src'},
-      install_requires=install_requires,
-      extras_require={
-          "connectors": connectors_extras,
-          "mysql": mysql_extras,
-          "postgres": postgres_extras,
-          "snowflake": snowflake_extras,
-      },
-      python_requires=">=3.9",
-      packages=find_packages("src"),
-      package_data={'': ['*.yaml']},
-      include_package_data=True,
-      description="Synthetic Data Generation with optional Differential Privacy",
-      url="https://github.com/gretelai/gretel-trainer",
-      license="https://gretel.ai/license/source-available-license",
-      classifiers=[
+connectors_extras = mysql_extras + postgres_extras + snowflake_extras + bigquery_extras
+
+setup(
+    name="gretel-trainer",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    package_dir={"": "src"},
+    install_requires=install_requires,
+    extras_require={
+        "connectors": connectors_extras,
+        "mysql": mysql_extras,
+        "postgres": postgres_extras,
+        "snowflake": snowflake_extras,
+        "bigquery": bigquery_extras,
+    },
+    python_requires=">=3.9",
+    packages=find_packages("src"),
+    package_data={"": ["*.yaml"]},
+    include_package_data=True,
+    description="Synthetic Data Generation with optional Differential Privacy",
+    url="https://github.com/gretelai/gretel-trainer",
+    license="https://gretel.ai/license/source-available-license",
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Free To Use But Restricted",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
-      ]
+    ],
 )

--- a/tests/relational/test_extractor.py
+++ b/tests/relational/test_extractor.py
@@ -120,10 +120,13 @@ def test_sample_table(target, expect, connector_art, tmpdir):
     assert "A001" not in df["id"]
 
 
-def test_sample_tables(connector_art, tmpdir):
-    config = ExtractorConfig(target_row_count=0.5)
+@pytest.mark.parametrize("sample_mode", ["random", "contiguous"])
+def test_sample_tables(sample_mode, connector_art, tmpdir):
+    config = ExtractorConfig(target_row_count=0.5, sample_mode=sample_mode)
     extractor = TableExtractor(
-        config=config, connector=connector_art, storage_dir=Path(tmpdir)
+        config=config,
+        connector=connector_art,
+        storage_dir=Path(tmpdir),
     )
     meta = extractor.sample_tables()
     paintings = meta["paintings"]


### PR DESCRIPTION
Use contiguous as the default mode. When using random try using both `func.random()` and `func.rand()` if either of those fails just fall back to contiguous mode, bq working now:

<img width="1136" alt="image" src="https://github.com/gretelai/trainer/assets/9696606/a3037c09-0435-4fb3-9396-a69f486e26d6">
