### PR TITLE
Core refactors

### DIFF
--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -50,9 +50,7 @@ class BackupRelationalData:
                 invented_table_metadata := rel_data.get_invented_table_metadata(table)
             ) is not None:
                 backup_table.invented_table_metadata = asdict(invented_table_metadata)
-            if (
-                producer_metadata := rel_data.get_producer_metadata(table)
-            ) is not None:
+            if (producer_metadata := rel_data.get_producer_metadata(table)) is not None:
                 backup_table.producer_metadata = asdict(producer_metadata)
             tables[table] = backup_table
             if producer_metadata is None:
@@ -62,9 +60,7 @@ class BackupRelationalData:
                         for key in rel_data.get_foreign_keys(table)
                     ]
                 )
-        return BackupRelationalData(
-            tables=tables, foreign_keys=foreign_keys
-        )
+        return BackupRelationalData(tables=tables, foreign_keys=foreign_keys)
 
 
 @dataclass

--- a/src/gretel_trainer/relational/backup.py
+++ b/src/gretel_trainer/relational/backup.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
 from gretel_trainer.relational.artifacts import ArtifactCollection
-from gretel_trainer.relational.core import ForeignKey, RelationalData
+from gretel_trainer.relational.core import ForeignKey, RelationalData, Scope
 
 
 @dataclass
@@ -12,6 +12,7 @@ class BackupRelationalDataTable:
     primary_key: list[str]
     columns: list[str]
     invented_table_metadata: Optional[dict[str, Any]] = None
+    producer_metadata: Optional[dict[str, Any]] = None
 
 
 @dataclass
@@ -32,25 +33,15 @@ class BackupForeignKey:
 
 
 @dataclass
-class BackupRelationalJson:
-    original_table_name: str
-    original_primary_key: list[str]
-    original_columns: list[str]
-    table_name_mappings: dict[str, str]
-
-
-@dataclass
 class BackupRelationalData:
     tables: dict[str, BackupRelationalDataTable]
     foreign_keys: list[BackupForeignKey]
-    relational_jsons: dict[str, BackupRelationalJson]
 
     @classmethod
     def from_relational_data(cls, rel_data: RelationalData) -> BackupRelationalData:
         tables = {}
         foreign_keys = []
-        relational_jsons = {}
-        for table in rel_data.list_all_tables():
+        for table in rel_data.list_all_tables(Scope.ALL):
             backup_table = BackupRelationalDataTable(
                 primary_key=rel_data.get_primary_key(table),
                 columns=rel_data.get_table_columns(table),
@@ -59,22 +50,20 @@ class BackupRelationalData:
                 invented_table_metadata := rel_data.get_invented_table_metadata(table)
             ) is not None:
                 backup_table.invented_table_metadata = asdict(invented_table_metadata)
+            if (
+                producer_metadata := rel_data.get_producer_metadata(table)
+            ) is not None:
+                backup_table.producer_metadata = asdict(producer_metadata)
             tables[table] = backup_table
-            foreign_keys.extend(
-                [
-                    BackupForeignKey.from_fk(key)
-                    for key in rel_data.get_foreign_keys(table)
-                ]
-            )
-        for key, rel_json in rel_data.relational_jsons.items():
-            relational_jsons[key] = BackupRelationalJson(
-                original_table_name=rel_json.original_table_name,
-                original_primary_key=rel_json.original_primary_key,
-                original_columns=rel_json.original_columns,
-                table_name_mappings=rel_json.table_name_mappings,
-            )
+            if producer_metadata is None:
+                foreign_keys.extend(
+                    [
+                        BackupForeignKey.from_fk(key)
+                        for key in rel_data.get_foreign_keys(table)
+                    ]
+                )
         return BackupRelationalData(
-            tables=tables, foreign_keys=foreign_keys, relational_jsons=relational_jsons
+            tables=tables, foreign_keys=foreign_keys
         )
 
 
@@ -139,10 +128,6 @@ class Backup:
                 )
                 for fk in relational_data.get("foreign_keys", [])
             ],
-            relational_jsons={
-                k: BackupRelationalJson(**v)
-                for k, v in relational_data.get("relational_jsons", {}).items()
-            },
         )
 
         backup = Backup(

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -277,7 +277,7 @@ class RelationalData:
 
         # If `table` is a producer of invented tables, we redo JSON ingestion
         # to ensure primary keys are set properly on invented tables
-        elif self._is_producer_of_invented_tables(table):
+        elif self.is_producer_of_invented_tables(table):
             removal_metadata = self._remove_relational_json(table)
             if (original_data := removal_metadata.data) is None:
                 raise MultiTableException("Original data with JSON is lost.")
@@ -507,7 +507,7 @@ class RelationalData:
         """
         if self._is_invented(table):
             raise MultiTableException("Cannot modify invented tables' data")
-        elif self._is_producer_of_invented_tables(table):
+        elif self.is_producer_of_invented_tables(table):
             removal_metadata = self._remove_relational_json(table)
         else:
             removal_metadata = _RemovedTableMetadata(
@@ -565,7 +565,7 @@ class RelationalData:
     def _is_invented(self, table: str) -> bool:
         return self.get_invented_table_metadata(table) is not None
 
-    def _is_producer_of_invented_tables(self, table: str) -> bool:
+    def is_producer_of_invented_tables(self, table: str) -> bool:
         return self.get_producer_metadata(table) is not None
 
     def get_modelable_table_names(self, table: str) -> list[str]:

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -263,7 +263,7 @@ class RelationalData:
             self._get_table_metadata(table).primary_key = primary_key
             self._clear_safe_ancestral_seed_columns(table)
 
-        # ...but if it has JSON and produced invented tables, we redo that whole process
+        # ...but if it has JSON and produced invented tables, we redo JSON ingestion
         # to make sure invented tables have primary keys set properly
         else:
             removal_metadata = self._remove_relational_json(table)
@@ -311,7 +311,7 @@ class RelationalData:
         Removes the RelationalJson instance and removes all invented tables from the graph
         (which in turn removes all edges (foreign keys) to/from other tables).
 
-        Returns a _RemovedTableMetadata object for restoring data in broader "update" contexts.
+        Returns a _RemovedTableMetadata object for restoring metadata in broader "update" contexts.
         """
         rel_json = self.relational_jsons[table]
 

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -525,7 +525,7 @@ class RelationalData:
         json_source_tables = [
             t
             for t in graph_nodes
-            if self._get_table_metadata(t).producer_metadata is not None
+            if self.get_producer_metadata(t) is not None
         ]
 
         modelable_tables = []
@@ -557,10 +557,10 @@ class RelationalData:
             return [t for t in graph_nodes if t not in invented_tables]
 
     def _is_invented(self, table: str) -> bool:
-        return self._get_table_metadata(table).invented_table_metadata is not None
+        return self.get_invented_table_metadata(table) is not None
 
     def _is_producer_of_invented_tables(self, table: str) -> bool:
-        return self._get_table_metadata(table).producer_metadata is not None
+        return self.get_producer_metadata(table) is not None
 
     def get_modelable_table_names(self, table: str) -> list[str]:
         """
@@ -704,7 +704,7 @@ class RelationalData:
         self._get_table_metadata(table).safe_ancestral_seed_columns = None
 
     def _get_fk_delegate_table(self, table: str) -> str:
-        if (pmeta := self._get_table_metadata(table).producer_metadata) is not None:
+        if (pmeta := self.get_producer_metadata(table)) is not None:
             return pmeta.invented_root_table_name
 
         return table

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -527,8 +527,8 @@ class RelationalData:
         """
         graph_nodes = list(self.graph.nodes)
 
-        json_source_tables = [
-            t for t in graph_nodes if self.get_producer_metadata(t) is not None
+        producer_tables = [
+            t for t in graph_nodes if self.is_producer_of_invented_tables(t)
         ]
 
         modelable_tables = []
@@ -544,7 +544,7 @@ class RelationalData:
                 if not invented_meta.empty:
                     modelable_tables.append(n)
             else:
-                if n not in json_source_tables:
+                if n not in producer_tables:
                     modelable_tables.append(n)
                     evaluatable_tables.append(n)
 

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -531,9 +531,7 @@ class RelationalData:
         graph_nodes = list(self.graph.nodes)
 
         json_source_tables = [
-            t
-            for t in graph_nodes
-            if self.get_producer_metadata(t) is not None
+            t for t in graph_nodes if self.get_producer_metadata(t) is not None
         ]
 
         modelable_tables = []
@@ -604,9 +602,7 @@ class RelationalData:
     ) -> Optional[InventedTableMetadata]:
         return self._get_table_metadata(table).invented_table_metadata
 
-    def get_producer_metadata(
-        self, table: str
-    ) -> Optional[ProducerMetadata]:
+    def get_producer_metadata(self, table: str) -> Optional[ProducerMetadata]:
         return self._get_table_metadata(table).producer_metadata
 
     def get_parents(self, table: str) -> list[str]:

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -228,6 +228,7 @@ class RelationalData:
         primary_key: UserFriendlyPrimaryKeyT,
         data: pd.DataFrame,
         invented_table_metadata: Optional[InventedTableMetadata] = None,
+        producer_metadata: Optional[ProducerMetadata] = None,
     ) -> None:
         primary_key = self._format_key_column(primary_key)
         metadata = TableMetadata(
@@ -594,6 +595,11 @@ class RelationalData:
         self, table: str
     ) -> Optional[InventedTableMetadata]:
         return self._get_table_metadata(table).invented_table_metadata
+
+    def get_producer_metadata(
+        self, table: str
+    ) -> Optional[ProducerMetadata]:
+        return self._get_table_metadata(table).producer_metadata
 
     def get_parents(self, table: str) -> list[str]:
         """

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -258,7 +258,9 @@ class RelationalData:
             self._add_rel_json_and_tables(table, new_rj_ingest)
             self._restore_fks_in_both_directions(table, removal_metadata)
 
-    def _restore_fks_in_both_directions(self, table: str, removal_metadata: _RemovedTableMetadata) -> None:
+    def _restore_fks_in_both_directions(
+        self, table: str, removal_metadata: _RemovedTableMetadata
+    ) -> None:
         for fk in removal_metadata.fks_to_parents:
             self.add_foreign_key_constraint(
                 table=table,
@@ -296,7 +298,9 @@ class RelationalData:
             data=rel_json.original_data,
             primary_key=rel_json.original_primary_key,
             fks_to_parents=self.get_foreign_keys(table),
-            fks_from_children=self._get_user_defined_fks_to_table(table),
+            fks_from_children=self._get_user_defined_fks_to_table(
+                rel_json.root_table_name
+            ),
         )
 
         for invented_table_name in rel_json.table_names:

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -277,7 +277,7 @@ class RelationalData:
         # If `table` is a producer of invented tables, we redo JSON ingestion
         # to ensure primary keys are set properly on invented tables
         elif self.is_producer_of_invented_tables(table):
-            removal_metadata = self._remove_relational_json(table)
+            removal_metadata = self._remove_producer(table)
             original_data = removal_metadata.data
             new_rj_ingest = relational_json.ingest(table, primary_key, original_data)
             if new_rj_ingest is None:
@@ -322,9 +322,9 @@ class RelationalData:
             if fk.parent_table_name == table and not self._is_invented(fk.table_name)
         ]
 
-    def _remove_relational_json(self, table: str) -> _RemovedTableMetadata:
+    def _remove_producer(self, table: str) -> _RemovedTableMetadata:
         """
-        Removes the producer table and all invented tables from the graph
+        Removes the producer table and all its invented tables from the graph
         (which in turn removes all edges (foreign keys) to/from other tables).
 
         Returns a _RemovedTableMetadata object for restoring metadata in broader "update" contexts.
@@ -505,7 +505,7 @@ class RelationalData:
         if self._is_invented(table):
             raise MultiTableException("Cannot modify invented tables' data")
         elif self.is_producer_of_invented_tables(table):
-            removal_metadata = self._remove_relational_json(table)
+            removal_metadata = self._remove_producer(table)
         else:
             removal_metadata = _RemovedTableMetadata(
                 data=pd.DataFrame(),  # we don't care about the old data

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -538,10 +538,7 @@ class RelationalData:
             return [t for t in graph_nodes if t not in invented_tables]
 
     def _is_invented(self, table: str) -> bool:
-        return (
-            table in self.graph.nodes
-            and self._get_table_metadata(table).invented_table_metadata is not None
-        )
+        return self._get_table_metadata(table).invented_table_metadata is not None
 
     def get_modelable_table_names(self, table: str) -> list[str]:
         """
@@ -562,9 +559,7 @@ class RelationalData:
             return []
 
     def get_public_name(self, table: str) -> Optional[str]:
-        if (
-            imeta := self._get_table_metadata(table).invented_table_metadata
-        ) is not None:
+        if (imeta := self.get_invented_table_metadata(table)) is not None:
             return imeta.original_table_name
 
         return table

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -151,6 +151,16 @@ class InventedTableMetadata:
     empty: bool
 
 
+@dataclass
+class ProducerMetadata:
+    invented_root_table_name: str
+    table_name_mappings: dict[str, str]
+
+    @property
+    def table_names(self) -> list[str]:
+        return list(self.table_name_mappings.values())
+
+
 class RelationalJson:
     def __init__(
         self,
@@ -188,7 +198,11 @@ class RelationalJson:
                 table_name_mappings=mappings,
             )
             commands = _generate_commands(rel_json, tables)
-            return (rel_json, commands)
+            producer_metadata = ProducerMetadata(
+                invented_root_table_name=mappings[table_name],
+                table_name_mappings=mappings,
+            )
+            return (rel_json, commands, producer_metadata)
 
     @property
     def root_table_name(self) -> str:
@@ -371,4 +385,4 @@ def get_json_columns(df: pd.DataFrame) -> list[str]:
 
 
 CommandsT = tuple[list[dict], list[dict]]
-IngestResponseT = tuple[RelationalJson, CommandsT]
+IngestResponseT = tuple[RelationalJson, CommandsT, ProducerMetadata]

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -255,7 +255,9 @@ def restore(
         )
         return None
 
-    return _denormalize_json(tables, rel_data, table_name_mappings, original_table_name)[original_columns]
+    return _denormalize_json(
+        tables, rel_data, table_name_mappings, original_table_name
+    )[original_columns]
 
 
 def _denormalize_json(
@@ -266,9 +268,7 @@ def _denormalize_json(
 ) -> pd.DataFrame:
     table_names = list(table_name_mappings.values())
     inverse_table_name_mappings = {v: k for k, v in table_name_mappings.items()}
-    table_dict: dict = {
-        inverse_table_name_mappings[k]: v for k, v in tables.items()
-    }
+    table_dict: dict = {inverse_table_name_mappings[k]: v for k, v in tables.items()}
     for table_name in list(reversed(table_names)):
         table_provenance_name = inverse_table_name_mappings[table_name]
         empty_fallback = pd.DataFrame(

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -161,171 +161,57 @@ class ProducerMetadata:
         return list(self.table_name_mappings.values())
 
 
-class RelationalJson:
-    def __init__(
-        self,
-        original_table_name: str,
-        original_primary_key: list[str],
-        original_columns: list[str],
-        original_data: Optional[pd.DataFrame],
-        table_name_mappings: dict[str, str],
-    ):
-        self.original_table_name = original_table_name
-        self.original_primary_key = original_primary_key
-        self.original_columns = original_columns
-        self.original_data = original_data
-        self.table_name_mappings = table_name_mappings
-
-    @classmethod
-    def ingest(
-        cls,
-        table_name: str,
-        primary_key: list[str],
-        df: pd.DataFrame,
-        json_columns: Optional[list[str]] = None,
-    ) -> Optional[IngestResponseT]:
-        tables = _normalize_json([(table_name, df.copy())], [], json_columns)
-        # If we created additional tables (from JSON lists) or added columns (from JSON dicts)
-        if len(tables) > 1 or len(tables[0][1].columns) > len(df.columns):
-            mappings = {name: sanitize_str(name) for name, _ in tables}
-            logger.info(f"Transformed JSON into {len(mappings)} tables for modeling.")
-            logger.debug(f"Invented table names: {list(mappings.values())}")
-            rel_json = RelationalJson(
-                original_table_name=table_name,
-                original_primary_key=primary_key,
-                original_data=df,
-                original_columns=list(df.columns),
-                table_name_mappings=mappings,
-            )
-            commands = _generate_commands(rel_json, tables)
-            producer_metadata = ProducerMetadata(
-                invented_root_table_name=mappings[table_name],
-                table_name_mappings=mappings,
-            )
-            return (rel_json, commands, producer_metadata)
-
-    @property
-    def root_table_name(self) -> str:
-        return self.table_name_mappings[self.original_table_name]
-
-    @property
-    def table_names(self) -> list[str]:
-        """Returns sanitized, model-friendly table names, *including* those of empty invented tables."""
-        return list(self.table_name_mappings.values())
-
-    @property
-    def inverse_table_name_mappings(self) -> dict[str, str]:
-        # Keys are sanitized, model-friendly names
-        # Values are "provenance" names (a^b>c) or the original table name
-        return {value: key for key, value in self.table_name_mappings.items()}
-
-    def restore(
-        self, tables: dict[str, pd.DataFrame], rel_data: _RelationalData
-    ) -> Optional[pd.DataFrame]:
-        """Reduces a set of tables (assumed to match the shapes created on initialization)
-        to a single table matching the shape of the original source table
-        """
-        # If the root invented table failed, we are completely out of luck
-        # (Missing invented child tables can be replaced with empty lists so we at least provide _something_)
-        if self.root_table_name not in tables:
-            logger.warning(
-                f"Cannot restore nested JSON data: root invented table `{self.root_table_name}` is missing from output tables."
-            )
-            return None
-
-        return self._denormalize_json(tables, rel_data)[self.original_columns]
-
-    def _denormalize_json(
-        self, tables: dict[str, pd.DataFrame], rel_data: _RelationalData
-    ) -> pd.DataFrame:
-        table_dict: dict = {
-            self.inverse_table_name_mappings[k]: v for k, v in tables.items()
-        }
-        for table_name in list(reversed(self.table_names)):
-            table_provenance_name = self.inverse_table_name_mappings[table_name]
-            empty_fallback = pd.DataFrame(
-                data={col: [] for col in rel_data.get_table_columns(table_name)},
-            )
-            table_df = table_dict.get(table_provenance_name, empty_fallback)
-
-            if table_df.empty and _is_invented_child_table(table_name, rel_data):
-                p_name = rel_data.get_foreign_keys(table_name)[0].parent_table_name
-                parent_name = self.inverse_table_name_mappings[p_name]
-                col_name = get_parent_column_name_from_child_table_name(
-                    table_provenance_name
-                )
-                kwargs = {col_name: table_dict[parent_name].apply(lambda x: [], axis=1)}
-                table_dict[parent_name] = table_dict[parent_name].assign(**kwargs)
-            else:
-                col_names = [col for col in table_df.columns if FIELD_SEPARATOR in col]
-                new_col_names = [col.replace(FIELD_SEPARATOR, ".") for col in col_names]
-                flat_df = table_df[col_names].rename(
-                    columns=dict(zip(col_names, new_col_names))
-                )
-                flat_dict = {
-                    k: {
-                        k1: v1
-                        for k1, v1 in v.items()
-                        if v1 is not np.nan and v1 is not None
-                    }
-                    for k, v in flat_df.to_dict("index").items()
-                }
-                dict_df = nulls_to_empty_dicts(
-                    pd.DataFrame.from_dict(
-                        {k: unflatten(v) for k, v in flat_dict.items()}, orient="index"
-                    )
-                )
-                nested_df = table_df.join(dict_df).drop(columns=col_names)
-                if _is_invented_child_table(table_name, rel_data):
-                    # we know there is exactly one foreign key on invented child tables...
-                    fk = rel_data.get_foreign_keys(table_name)[0]
-                    # ...with exactly one column
-                    fk_col = fk.columns[0]
-                    p_name = fk.parent_table_name
-                    parent_name = self.inverse_table_name_mappings[p_name]
-                    nested_df = (
-                        nested_df.sort_values(ORDER_COLUMN)
-                        .groupby(fk_col)[CONTENT_COLUMN]
-                        .agg(list)
-                    )
-                    col_name = get_parent_column_name_from_child_table_name(
-                        table_provenance_name
-                    )
-                    table_dict[parent_name] = table_dict[parent_name].join(
-                        nested_df.rename(col_name)
-                    )
-                    table_dict[parent_name][col_name] = nulls_to_empty_lists(
-                        table_dict[parent_name][col_name]
-                    )
-                table_dict[table_provenance_name] = nested_df
-        return table_dict[self.original_table_name]
+def ingest(
+    table_name: str,
+    primary_key: list[str],
+    df: pd.DataFrame,
+    json_columns: Optional[list[str]] = None,
+) -> Optional[IngestResponseT]:
+    tables = _normalize_json([(table_name, df.copy())], [], json_columns)
+    # If we created additional tables (from JSON lists) or added columns (from JSON dicts)
+    if len(tables) > 1 or len(tables[0][1].columns) > len(df.columns):
+        mappings = {name: sanitize_str(name) for name, _ in tables}
+        logger.info(f"Transformed JSON into {len(mappings)} tables for modeling.")
+        logger.debug(f"Invented table names: {list(mappings.values())}")
+        commands = _generate_commands(
+            tables=tables,
+            table_name_mappings=mappings,
+            original_table_name=table_name,
+            original_primary_key=primary_key,
+        )
+        producer_metadata = ProducerMetadata(
+            invented_root_table_name=mappings[table_name],
+            table_name_mappings=mappings,
+        )
+        return (commands, producer_metadata)
 
 
 def _generate_commands(
-    rel_json: RelationalJson, tables: list[tuple[str, pd.DataFrame]]
+    tables: list[tuple[str, pd.DataFrame]],
+    table_name_mappings: dict[str, str],
+    original_table_name: str,
+    original_primary_key: list[str],
 ) -> CommandsT:
     """
     Returns lists of keyword arguments designed to be passed to a
     RelationalData instance's _add_single_table and add_foreign_key methods
     """
-    tables_to_add = {rel_json.table_name_mappings[name]: df for name, df in tables}
+    tables_to_add = {table_name_mappings[name]: df for name, df in tables}
+    root_table_name = table_name_mappings[original_table_name]
 
     _add_single_table = []
     add_foreign_key = []
 
     for table_name, table_df in tables_to_add.items():
-        if table_name == rel_json.root_table_name:
-            table_pk = rel_json.original_primary_key + [PRIMARY_KEY_COLUMN]
+        if table_name == root_table_name:
+            table_pk = original_primary_key + [PRIMARY_KEY_COLUMN]
         else:
             table_pk = [PRIMARY_KEY_COLUMN]
         table_df.index.rename(PRIMARY_KEY_COLUMN, inplace=True)
         table_df.reset_index(inplace=True)
-        invented_root_table_name = rel_json.table_name_mappings[
-            rel_json.original_table_name
-        ]
         metadata = InventedTableMetadata(
-            invented_root_table_name=invented_root_table_name,
-            original_table_name=rel_json.original_table_name,
+            invented_root_table_name=root_table_name,
+            original_table_name=original_table_name,
             empty=table_df.empty,
         )
         _add_single_table.append(
@@ -339,7 +225,7 @@ def _generate_commands(
 
     for table_name, table_df in tables_to_add.items():
         for column in get_id_columns(table_df):
-            referred_table = rel_json.table_name_mappings[
+            referred_table = table_name_mappings[
                 get_parent_table_name_from_child_id_column(column)
             ]
             add_foreign_key.append(
@@ -351,6 +237,96 @@ def _generate_commands(
                 }
             )
     return (_add_single_table, add_foreign_key)
+
+
+def restore(
+    tables: dict[str, pd.DataFrame],
+    rel_data: _RelationalData,
+    root_table_name: str,
+    original_columns: list[str],
+    table_name_mappings: dict[str, str],
+    original_table_name: str,
+) -> Optional[pd.DataFrame]:
+    # If the root invented table is not present, we are completely out of luck
+    # (Missing invented child tables can be replaced with empty lists so we at least provide _something_)
+    if root_table_name not in tables:
+        logger.warning(
+            f"Cannot restore nested JSON data: root invented table `{root_table_name}` is missing from output tables."
+        )
+        return None
+
+    return _denormalize_json(tables, rel_data, table_name_mappings, original_table_name)[original_columns]
+
+
+def _denormalize_json(
+    tables: dict[str, pd.DataFrame],
+    rel_data: _RelationalData,
+    table_name_mappings: dict[str, str],
+    original_table_name: str,
+) -> pd.DataFrame:
+    table_names = list(table_name_mappings.values())
+    inverse_table_name_mappings = {v: k for k, v in table_name_mappings.items()}
+    table_dict: dict = {
+        inverse_table_name_mappings[k]: v for k, v in tables.items()
+    }
+    for table_name in list(reversed(table_names)):
+        table_provenance_name = inverse_table_name_mappings[table_name]
+        empty_fallback = pd.DataFrame(
+            data={col: [] for col in rel_data.get_table_columns(table_name)},
+        )
+        table_df = table_dict.get(table_provenance_name, empty_fallback)
+
+        if table_df.empty and _is_invented_child_table(table_name, rel_data):
+            p_name = rel_data.get_foreign_keys(table_name)[0].parent_table_name
+            parent_name = inverse_table_name_mappings[p_name]
+            col_name = get_parent_column_name_from_child_table_name(
+                table_provenance_name
+            )
+            kwargs = {col_name: table_dict[parent_name].apply(lambda x: [], axis=1)}
+            table_dict[parent_name] = table_dict[parent_name].assign(**kwargs)
+        else:
+            col_names = [col for col in table_df.columns if FIELD_SEPARATOR in col]
+            new_col_names = [col.replace(FIELD_SEPARATOR, ".") for col in col_names]
+            flat_df = table_df[col_names].rename(
+                columns=dict(zip(col_names, new_col_names))
+            )
+            flat_dict = {
+                k: {
+                    k1: v1
+                    for k1, v1 in v.items()
+                    if v1 is not np.nan and v1 is not None
+                }
+                for k, v in flat_df.to_dict("index").items()
+            }
+            dict_df = nulls_to_empty_dicts(
+                pd.DataFrame.from_dict(
+                    {k: unflatten(v) for k, v in flat_dict.items()}, orient="index"
+                )
+            )
+            nested_df = table_df.join(dict_df).drop(columns=col_names)
+            if _is_invented_child_table(table_name, rel_data):
+                # we know there is exactly one foreign key on invented child tables...
+                fk = rel_data.get_foreign_keys(table_name)[0]
+                # ...with exactly one column
+                fk_col = fk.columns[0]
+                p_name = fk.parent_table_name
+                parent_name = inverse_table_name_mappings[p_name]
+                nested_df = (
+                    nested_df.sort_values(ORDER_COLUMN)
+                    .groupby(fk_col)[CONTENT_COLUMN]
+                    .agg(list)
+                )
+                col_name = get_parent_column_name_from_child_table_name(
+                    table_provenance_name
+                )
+                table_dict[parent_name] = table_dict[parent_name].join(
+                    nested_df.rename(col_name)
+                )
+                table_dict[parent_name][col_name] = nulls_to_empty_lists(
+                    table_dict[parent_name][col_name]
+                )
+            table_dict[table_provenance_name] = nested_df
+    return table_dict[original_table_name]
 
 
 def get_json_columns(df: pd.DataFrame) -> list[str]:
@@ -385,4 +361,4 @@ def get_json_columns(df: pd.DataFrame) -> list[str]:
 
 
 CommandsT = tuple[list[dict], list[dict]]
-IngestResponseT = tuple[RelationalJson, CommandsT, ProducerMetadata]
+IngestResponseT = tuple[CommandsT, ProducerMetadata]

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -45,7 +45,7 @@ from gretel_trainer.relational.core import (
     Scope,
     skip_table,
 )
-from gretel_trainer.relational.json import InventedTableMetadata, RelationalJson
+from gretel_trainer.relational.json import InventedTableMetadata, ProducerMetadata
 from gretel_trainer.relational.log import silent_logs
 from gretel_trainer.relational.model_config import (
     get_model_key,
@@ -172,17 +172,17 @@ class MultiTable:
         for table_name, table_backup in backup.relational_data.tables.items():
             source_data = pd.read_csv(self._working_dir / f"source_{table_name}.csv")
             invented_table_metadata = None
+            producer_metadata = None
             if (imeta := table_backup.invented_table_metadata) is not None:
-                invented_table_metadata = InventedTableMetadata(
-                    invented_root_table_name=imeta["invented_root_table_name"],
-                    original_table_name=imeta["original_table_name"],
-                    empty=imeta["empty"],
-                )
+                invented_table_metadata = InventedTableMetadata(**imeta)
+            if (pmeta := table_backup.producer_metadata) is not None:
+                producer_metadata = ProducerMetadata(**pmeta)
             self.relational_data._add_single_table(
                 name=table_name,
                 primary_key=table_backup.primary_key,
                 data=source_data,
                 invented_table_metadata=invented_table_metadata,
+                producer_metadata=producer_metadata,
             )
         for fk_backup in backup.relational_data.foreign_keys:
             self.relational_data.add_foreign_key_constraint(
@@ -191,15 +191,6 @@ class MultiTable:
                 referred_table=fk_backup.referred_table,
                 referred_columns=fk_backup.referred_columns,
             )
-        for key, rel_json_backup in backup.relational_data.relational_jsons.items():
-            relational_json = RelationalJson(
-                original_table_name=rel_json_backup.original_table_name,
-                original_primary_key=rel_json_backup.original_primary_key,
-                original_columns=rel_json_backup.original_columns,
-                original_data=None,
-                table_name_mappings=rel_json_backup.table_name_mappings,
-            )
-            self.relational_data.relational_jsons[key] = relational_json
 
         # Debug summary
         debug_summary_id = backup.artifact_collection.gretel_debug_summary

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -57,7 +57,7 @@ def test_backup_relational_data_with_json(documents):
                         "purchases": "purchases-sfx",
                         "purchases^data>years": "purchases-data-years-sfx",
                     },
-                }
+                },
             ),
             "purchases-sfx": BackupRelationalDataTable(
                 primary_key=["id", "~PRIMARY_KEY_ID~"],

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -8,7 +8,6 @@ from gretel_trainer.relational.backup import (
     BackupGenerate,
     BackupRelationalData,
     BackupRelationalDataTable,
-    BackupRelationalJson,
     BackupSyntheticsTrain,
     BackupTransformsTrain,
 )
@@ -34,7 +33,6 @@ def test_backup_relational_data(trips):
                 referred_columns=["id"],
             )
         ],
-        relational_jsons={},
     )
 
     assert BackupRelationalData.from_relational_data(trips) == expected
@@ -45,6 +43,21 @@ def test_backup_relational_data_with_json(documents):
         tables={
             "users": BackupRelationalDataTable(
                 primary_key=["id"], columns=["id", "name"]
+            ),
+            "purchases": BackupRelationalDataTable(
+                primary_key=["id"],
+                columns=[
+                    "id",
+                    "user_id",
+                    "data",
+                ],
+                producer_metadata={
+                    "invented_root_table_name": "purchases-sfx",
+                    "table_name_mappings": {
+                        "purchases": "purchases-sfx",
+                        "purchases^data>years": "purchases-data-years-sfx",
+                    },
+                }
             ),
             "purchases-sfx": BackupRelationalDataTable(
                 primary_key=["id", "~PRIMARY_KEY_ID~"],
@@ -95,17 +108,6 @@ def test_backup_relational_data_with_json(documents):
                 referred_columns=["~PRIMARY_KEY_ID~"],
             ),
         ],
-        relational_jsons={
-            "purchases": BackupRelationalJson(
-                original_table_name="purchases",
-                original_primary_key=["id"],
-                original_columns=["id", "user_id", "data"],
-                table_name_mappings={
-                    "purchases": "purchases-sfx",
-                    "purchases^data>years": "purchases-data-years-sfx",
-                },
-            ),
-        },
     )
 
     assert BackupRelationalData.from_relational_data(documents) == expected
@@ -131,7 +133,6 @@ def test_backup():
                 referred_columns=["id"],
             )
         ],
-        relational_jsons={},
     )
     backup_classify = BackupClassify(
         model_ids={

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -134,17 +134,24 @@ def test_get_modelable_table_names(documents):
 
 def test_get_modelable_names_ignores_empty_mapped_tables(bball):
     # The `suspensions` column in the source data contained empty lists for all records.
-    # We need to hold onto that table name on the RelationalJson instance to support
-    # denormalizing back to the original source data shape. It is therefore exposed
-    # in the `table_names` attribute on RelationalJson...
-    assert set(bball.relational_jsons["bball"].table_names) == {
+    # We need to hold onto that table name to support denormalizing back to the original
+    # source data shape. It is therefore present when listing ALL tables...
+    assert set(bball.list_all_tables(Scope.ALL)) == {
+        "bball",
         "bball-sfx",
         "bball-teams-sfx",
         "bball-suspensions-sfx",
     }
 
-    # ...BUT clients of RelationalData only care about invented tables that can be modeled
-    # (i.e. that contain data), so that class does not expose the empty table.
+    # ...and the producer metadata is aware of it...
+    assert set(bball.get_producer_metadata("bball").table_names) == {
+        "bball-sfx",
+        "bball-teams-sfx",
+        "bball-suspensions-sfx",
+    }
+
+    # ...BUT most clients only care about invented tables that can be modeled
+    # (i.e. that contain data), so the empty table does not appear in these contexts:
     assert set(bball.get_modelable_table_names("bball")) == {
         "bball-sfx",
         "bball-teams-sfx",

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -134,6 +134,7 @@ def test_get_modelable_table_names(documents):
 
 def test_get_modelable_names_ignores_empty_mapped_tables(bball):
     # The `suspensions` column in the source data contained empty lists for all records.
+    # The normalization process transforms that into a standalone, empty table.
     # We need to hold onto that table name to support denormalizing back to the original
     # source data shape. It is therefore present when listing ALL tables...
     assert set(bball.list_all_tables(Scope.ALL)) == {


### PR DESCRIPTION
No user-facing changes here, strictly an internal refactor.

Previously, tables with JSON columns got "extra special treatment": after creating invented tables from them, we added the invented tables to the `RelationalData` graph as nodes, but _not_ the source table itself; instead, metadata about that original table was stored in a `RelationalJson` object responsible for knowing everything necessary to transform invented tables back to the original shape. Then the `RelationalData` stored a dictionary of those objects. This was always a bit clunky and added a lot of mental overhead when trying to reason about the internal state.

In the spirit of "cattle, not pets", this PR makes what we now call "producer" tables more similar to normal and invented tables. Probably the key takeaway is that **every table is a node in the graph**, whether it is a "normal" table, an invented table, or a producer of invented tables. All state for a given table is stored on the graph node. This brings several benefits:
- the JSON module, with all its (de)normalizing transformation functions, is now stateless—we store all the table-mapping information on the producer table graph node
- backups no longer need to care about this extra collection of objects (`RelationalJson`s)—they just write down everything known about all tables, and (by extension) the restore process is simplified. (`RelationalJson` backup was also a bit "lossy"; no more!)
- elevating the concept of "producer tables" helps establish a more sustainable pattern for if we ever invent tables for other reasons in the future

There are also a few internal helper methods added to generally make things more readable.