### PR TITLE
Source on disk

### DIFF
--- a/src/gretel_trainer/relational/connectors.py
+++ b/src/gretel_trainer/relational/connectors.py
@@ -9,7 +9,6 @@ Gretel Transforms, Classify, Synthetics, or a combination of both.
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -96,7 +95,7 @@ class Connector:
             )
 
         storage_dir_path = Path(storage_dir)
-        os.makedirs(storage_dir_path, exist_ok=True)
+        storage_dir_path.mkdir(parents=True, exist_ok=True)
 
         extractor = TableExtractor(
             config=config, connector=self, storage_dir=storage_dir_path

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -15,7 +15,6 @@ Please see the specific docs for the "RelationalData" class on how to do this.
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import tempfile
 from dataclasses import dataclass, replace
@@ -127,7 +126,7 @@ class RelationalData:
 
     def __init__(self, directory: Optional[Union[str, Path]] = None):
         self.dir = Path(directory or DEFAULT_RELATIONAL_SOURCE_DIR)
-        os.makedirs(self.dir, exist_ok=True)
+        self.dir.mkdir(parents=True, exist_ok=True)
         self.graph = networkx.DiGraph()
 
     @property

--- a/src/gretel_trainer/relational/extractor.py
+++ b/src/gretel_trainer/relational/extractor.py
@@ -40,7 +40,7 @@ class ExtractorConfig:
 
     target_row_count: float = -1.0
     """
-    The target number of rows (or ratio of rows) to sample. This will be used as the sample target for "leaf" tables, 
+    The target number of rows (or ratio of rows) to sample. This will be used as the sample target for "leaf" tables,
     or tables that do not have any references to their primary keys. If this number is >= 1 then
     that number of rows will be used, if the value is between 0..1 then it is considered to be a percetange
     of the total number of rows. A 0 value will just extract headers and -1 will extract entire tables.
@@ -236,7 +236,7 @@ class TableExtractor:
 
         self._storage_dir = storage_dir
 
-        self._relational_data = RelationalData()
+        self._relational_data = RelationalData(directory=self._storage_dir)
         self.table_order = []
         self._chunk_size = 50_000
 
@@ -268,7 +268,7 @@ class TableExtractor:
         if extracted_tables is None:
             extracted_tables = []
 
-        rel_data = RelationalData()
+        rel_data = RelationalData(directory=self._storage_dir)
         inspector = inspect(self._connector.engine)
         foreign_keys: list[tuple[str, dict]] = []
 

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import re
 from dataclasses import dataclass
-from json import JSONDecodeError, loads
+from json import JSONDecodeError, dumps, loads
 from typing import Any, Optional, Protocol, Union
 
 import numpy as np
@@ -12,8 +12,6 @@ import pandas as pd
 from unflatten import unflatten
 
 logger = logging.getLogger(__name__)
-
-PREVIEW_ROW_COUNT = 5
 
 # JSON dict to multi-column and list to multi-table
 
@@ -129,6 +127,34 @@ def make_suffix(s):
     return hashlib.sha256(s.encode("utf-8")).hexdigest()[:10]
 
 
+def jsonencode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    def _jsonencode(x):
+        if isinstance(x, str):
+            return x
+        elif isinstance(x, (dict, list)):
+            return dumps(x)
+
+    copy = df.copy()
+    for col in cols:
+        copy[col] = copy[col].map(_jsonencode)
+
+    return copy
+
+
+def jsondecode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    def _jsondecode(obj):
+        try:
+            return loads(obj)
+        except (ValueError, TypeError, JSONDecodeError):
+            return obj
+
+    copy = df.copy()
+    for col in cols:
+        copy[col] = copy[col].map(_jsondecode)
+
+    return copy
+
+
 class _RelationalData(Protocol):
     def get_foreign_keys(
         self, table: str
@@ -165,9 +191,11 @@ def ingest(
     table_name: str,
     primary_key: list[str],
     df: pd.DataFrame,
-    json_columns: Optional[list[str]] = None,
+    json_columns: list[str],
 ) -> Optional[IngestResponseT]:
-    tables = _normalize_json([(table_name, df.copy())], [], json_columns)
+    json_decoded = jsondecode(df, json_columns)
+    tables = _normalize_json([(table_name, json_decoded)], [], json_columns)
+
     # If we created additional tables (from JSON lists) or added columns (from JSON dicts)
     if len(tables) > 1 or len(tables[0][1].columns) > len(df.columns):
         mappings = {name: sanitize_str(name) for name, _ in tables}
@@ -336,25 +364,26 @@ def get_json_columns(df: pd.DataFrame) -> list[str]:
 
     Raises an error if *all* columns are lists, as that is not currently supported.
     """
-    column_previews = {
-        col: preview_data
+    object_cols = {
+        col: data
         for col in df.columns
-        if df.dtypes[col] == "object"
-        and len(preview_data := df[col].dropna().head(PREVIEW_ROW_COUNT)) > 0
+        if df.dtypes[col] == "object" and len(data := df[col].dropna()) > 0
     }
 
-    if len(column_previews) == 0:
+    if len(object_cols) == 0:
         return []
 
     list_cols = [
-        col for col, series in column_previews.items() if series.apply(is_list).all()
+        col for col, series in object_cols.items() if series.apply(is_list).all()
     ]
 
     if len(list_cols) == len(df.columns):
         raise ValueError("Cannot accept tables with JSON lists in all columns")
 
     dict_cols = [
-        col for col, series in column_previews.items() if series.apply(is_dict).all()
+        col
+        for col, series in object_cols.items()
+        if col not in list_cols and series.apply(is_dict).all()
     ]
 
     return dict_cols + list_cols

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -128,6 +128,14 @@ def make_suffix(s):
 
 
 def jsonencode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """
+    Returns a dataframe with the specified columns transformed such that their JSON-like
+    values can be written to CSV and later re-read back to Pandas from CSV.
+    """
+    # Save memory and return the *original dataframe* (not a copy!) if no columns to transform
+    if len(cols) == 0:
+        return df
+
     def _jsonencode(x):
         if isinstance(x, str):
             return x
@@ -142,6 +150,13 @@ def jsonencode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
 
 
 def jsondecode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """
+    Returns a dataframe with the specified columns parsed from JSON to Python objects.
+    """
+    # Save memory and return the *original dataframe* (not a copy!) if no columns to transform
+    if len(cols) == 0:
+        return df
+
     def _jsondecode(obj):
         try:
             return loads(obj)

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -1186,7 +1186,7 @@ def _table_trained_successfully(train_state: TransformsTrain, table: str) -> boo
 
 def _mkdir(name: str) -> Path:
     d = Path(name)
-    os.makedirs(d, exist_ok=True)
+    d.mkdir(parents=True, exist_ok=True)
     return d
 
 

--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -575,18 +575,9 @@ class MultiTable:
         self, configs: dict[str, GretelModelConfig]
     ) -> None:
         for table, config in configs.items():
-            transform_config = make_transform_config(
-                self.relational_data, table, config
-            )
-
-            # Ensure consistent, friendly data source names in Console
-            table_data = self.relational_data.get_table_data(table)
-            transforms_train_path = self._working_dir / f"transforms_train_{table}.csv"
-            table_data.to_csv(transforms_train_path, index=False)
-
-            # Create model
             model = self._project.create_model_obj(
-                model_config=transform_config, data_source=str(transforms_train_path)
+                model_config=make_transform_config(self.relational_data, table, config),
+                data_source=str(self.relational_data.get_table_source(table)),
             )
             self._transforms_train.models[table] = model
 

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -161,7 +161,7 @@ def _setup_nba(directory: str, synthetic: bool):
         referred_columns=["id"],
     )
 
-    yield rel_data, states, cities, teams
+    return rel_data, states, cities, teams
 
 
 @pytest.fixture()

--- a/tests/relational/test_ancestral_strategy.py
+++ b/tests/relational/test_ancestral_strategy.py
@@ -468,8 +468,8 @@ def test_generation_job(pets):
 
 
 def test_generation_job_seeds_go_back_multiple_generations(source_nba, synthetic_nba):
-    source_nba = next(source_nba)[0]
-    synthetic_nba = next(synthetic_nba)[0]
+    source_nba = source_nba[0]
+    synthetic_nba = synthetic_nba[0]
     output_tables = {
         "cities": ancestry.get_table_data_with_ancestors(synthetic_nba, "cities"),
         "states": ancestry.get_table_data_with_ancestors(synthetic_nba, "states"),

--- a/tests/relational/test_ancestry.py
+++ b/tests/relational/test_ancestry.py
@@ -101,8 +101,8 @@ def test_tpch_add_and_remove_ancestor_data(tpch):
 
 
 def test_ancestral_data_from_different_tablesets(source_nba, synthetic_nba):
-    source_nba = next(source_nba)[0]
-    _, custom_states, custom_cities, custom_teams = next(synthetic_nba)
+    source_nba = source_nba[0]
+    _, custom_states, custom_cities, custom_teams = synthetic_nba
 
     # By default, get data from source
     source_teams_with_ancestors = ancestry.get_table_data_with_ancestors(
@@ -211,7 +211,7 @@ def test_get_seed_safe_multigenerational_columns_1(pets):
 
 
 def test_get_seed_safe_multigenerational_columns_2(source_nba):
-    source_nba = next(source_nba)[0]
+    source_nba = source_nba[0]
     table_cols = ancestry.get_seed_safe_multigenerational_columns(source_nba)
 
     expected = {

--- a/tests/relational/test_ancestry.py
+++ b/tests/relational/test_ancestry.py
@@ -101,8 +101,8 @@ def test_tpch_add_and_remove_ancestor_data(tpch):
 
 
 def test_ancestral_data_from_different_tablesets(source_nba, synthetic_nba):
-    source_nba, _, _, _ = source_nba
-    _, custom_states, custom_cities, custom_teams = synthetic_nba
+    source_nba = next(source_nba)[0]
+    _, custom_states, custom_cities, custom_teams = next(synthetic_nba)
 
     # By default, get data from source
     source_teams_with_ancestors = ancestry.get_table_data_with_ancestors(
@@ -211,7 +211,7 @@ def test_get_seed_safe_multigenerational_columns_1(pets):
 
 
 def test_get_seed_safe_multigenerational_columns_2(source_nba):
-    source_nba = source_nba[0]
+    source_nba = next(source_nba)[0]
     table_cols = ancestry.get_seed_safe_multigenerational_columns(source_nba)
 
     expected = {

--- a/tests/relational/test_common_strategy.py
+++ b/tests/relational/test_common_strategy.py
@@ -4,18 +4,18 @@ import gretel_trainer.relational.strategies.common as common
 from gretel_trainer.relational.core import RelationalData
 
 
-def test_composite_pk_columns():
-    table = pd.DataFrame(
+def test_composite_pk_columns(tmpdir):
+    df = pd.DataFrame(
         data={
             "letter": ["a", "a", "a", "a", "b", "b", "b", "b"],
             "number": [1, 2, 3, 4, 1, 2, 3, 4],
         }
     )
-    rel_data = RelationalData()
+    rel_data = RelationalData(directory=tmpdir)
     rel_data.add_table(
         name="table",
         primary_key=["letter", "number"],
-        data=table,
+        data=df,
     )
 
     result = common.make_composite_pk_columns(
@@ -45,18 +45,18 @@ def test_composite_pk_columns():
     assert len(set(result[1])) == 4
 
 
-def test_composite_pk_columns_2():
-    table = pd.DataFrame(
+def test_composite_pk_columns_2(tmpdir):
+    df = pd.DataFrame(
         data={
             "letter": ["a", "a", "a", "a", "b", "b", "b", "b"],
             "number": [1, 2, 3, 4, 5, 6, 7, 8],
         }
     )
-    rel_data = RelationalData()
+    rel_data = RelationalData(directory=tmpdir)
     rel_data.add_table(
         name="table",
         primary_key=["letter", "number"],
-        data=table,
+        data=df,
     )
 
     result = common.make_composite_pk_columns(

--- a/tests/relational/test_connectors.py
+++ b/tests/relational/test_connectors.py
@@ -7,7 +7,7 @@ from gretel_trainer.relational.connectors import sqlite_conn
 from gretel_trainer.relational.core import MultiTableException, Scope
 
 
-def test_extract_subsets_of_relational_data(example_dbs):
+def test_extract_subsets_of_relational_data(example_dbs, tmpdir):
     with tempfile.NamedTemporaryFile() as f:
         con = sqlite3.connect(f.name)
         cur = con.cursor()
@@ -17,11 +17,14 @@ def test_extract_subsets_of_relational_data(example_dbs):
         connector = sqlite_conn(f.name)
 
         with pytest.raises(MultiTableException):
-            connector.extract(only={"users"}, ignore={"events"})
+            connector.extract(only={"users"}, ignore={"events"}, storage_dir=tmpdir)
 
-        only = connector.extract(only={"users", "events", "products"})
+        only = connector.extract(
+            only={"users", "events", "products"}, storage_dir=tmpdir
+        )
         ignore = connector.extract(
-            ignore={"distribution_center", "order_items", "inventory_items"}
+            ignore={"distribution_center", "order_items", "inventory_items"},
+            storage_dir=tmpdir,
         )
 
     expected_tables = {"users", "events", "products"}

--- a/tests/relational/test_train_transforms.py
+++ b/tests/relational/test_train_transforms.py
@@ -44,7 +44,7 @@ def test_train_transforms_only_includes_specified_tables(ecom, tmpdir, project):
     assert set(transforms_train.models.keys()) == {"users"}
     project.create_model_obj.assert_called_with(
         model_config=ANY,  # a tailored transforms config, in dict form
-        data_source=f"{tmpdir}/transforms_train_users.csv",
+        data_source=f"{tmpdir}/users.csv",
     )
 
 


### PR DESCRIPTION
Instead of storing tables' source data as Pandas DataFrames in memory, store them as CSV files on disk. Users can now provide either a dataframe or a string/Path to a CSV when calling `add_table`.

I did some initial profiling using the [Airline db from relational fit](https://relational.fit.cvut.cz/dataset/Airline), which self-reports as being 455MB. I used [tracemalloc](https://docs.python.org/3/library/tracemalloc.html) to measure both the "resting memory footprint" at certain checkpoints, as well as the peak memory size between those checkpoints. The table compares current released code on main / Trainer 0.9.0 with the code on this branch. 

Using the first row and main branch as an example, the way to read this table is:
> While running on `main` branch, after instantiating a Connector, the standing memory load was `1,132,735` bytes. While that method was running the memory spiked as high as `1,134,936`.

| Checkpoint | Main current | Main peak | Branch current | Branch peak |
| - | - | - | - | - |
| `conn = Connector.from_conn_str(...)` | 1,132,735 | 1,134,936 | 1,132,561 | 1,134,762 |
| `rd = conn.extract()` | 321,629,892 | 1,270,347,471 | 4,313,712 | 1,270,054,369 |
| `mt = MultiTable(rd)` | 322,222,376 | 923,687,442 | 4,902,519 | 5,140,588 |
| `mt.train_transforms(...)` | 323,666,151 | 628,013,664 | 6,285,388 | 6,328,929 |

Some observations:
- the general "standing pressure" is much lower since we're only storing pointers to files in memory when nothing else is actively going on
- largest memory spike is during extraction; no difference between this branch and main
- since transforms models train on unaltered source data, we don't need to load the data into memory at all (we now just pass along the file pointer as the data source), which is why that bottom-right corner stays so nice and small.
