### PR TITLE
B2 backwards compatibility

### DIFF
--- a/notebooks/benchmark.ipynb
+++ b/notebooks/benchmark.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "When using your own data, indicate the datatype (select between: \"tabular_mixed\", \"tabular_numeric\", \"natural_language\", and \"time_series\"). Learn more in the [Benchmark docs](https://docs.gretel.ai/reference/benchmark#docs-internal-guid-31c7e29f-7fff-7936-54f8-737618a7e7f3).\n",
+    "When using your own data, indicate the datatype (select between: \"tabular\", \"natural_language\", and \"time_series\"). Learn more in the [Benchmark docs](https://docs.gretel.ai/reference/benchmark#docs-internal-guid-31c7e29f-7fff-7936-54f8-737618a7e7f3).\n",
     "\n",
     "Running in Google Colab? You can add your files to the Colab file system, and indicate the path like: \"/content/my_files/data.csv\""
    ]
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# my_data = b.make_dataset(\"/PATH/TO/MY_DATASET.csv\", name=\"my-data\", datatype=\"INDICATE_DATATYPE\")"
+    "# my_data = b.create_dataset(\"/PATH/TO/MY_DATASET.csv\", name=\"my-data\", datatype=\"INDICATE_DATATYPE\")"
    ]
   },
   {

--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -4,6 +4,11 @@ from gretel_trainer.benchmark.comparison import Comparison, compare
 from gretel_trainer.benchmark.core import Datatype
 from gretel_trainer.benchmark.custom.datasets import make_dataset
 from gretel_trainer.benchmark.gretel.datasets import GretelDatasetRepo
+from gretel_trainer.benchmark.gretel.datasets_backwards_compatibility import (
+    get_gretel_dataset,
+    list_gretel_dataset_tags,
+    list_gretel_datasets,
+)
 from gretel_trainer.benchmark.gretel.models import (
     GretelACTGAN,
     GretelAmplify,

--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from gretel_trainer.benchmark.comparison import Comparison, compare
 from gretel_trainer.benchmark.core import Datatype
-from gretel_trainer.benchmark.custom.datasets import make_dataset
+from gretel_trainer.benchmark.custom.datasets import create_dataset, make_dataset
 from gretel_trainer.benchmark.gretel.datasets import GretelDatasetRepo
 from gretel_trainer.benchmark.gretel.datasets_backwards_compatibility import (
     get_gretel_dataset,

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -13,11 +13,7 @@ from gretel_client.helpers import poll
 from gretel_client.projects import Project, create_project, search_projects
 from gretel_client.projects.jobs import Job
 
-from gretel_trainer.benchmark.core import (
-    BenchmarkConfig,
-    BenchmarkException,
-    Dataset,
-)
+from gretel_trainer.benchmark.core import BenchmarkConfig, BenchmarkException, Dataset
 from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
 from gretel_trainer.benchmark.custom.strategy import CustomStrategy

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -17,7 +17,6 @@ from gretel_trainer.benchmark.core import (
     BenchmarkConfig,
     BenchmarkException,
     Dataset,
-    log,
 )
 from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -128,7 +128,8 @@ class Comparison:
 
         self.config.working_dir.mkdir(exist_ok=True)
         self.datasets = [
-            _make_dataset(dataset, self.config.working_dir) for dataset in datasets
+            _standardize_dataset(dataset, self.config.working_dir)
+            for dataset in datasets
         ]
         self._gretel_executors: dict[RunKey, Executor] = {}
         self._custom_executors: dict[RunKey, Executor] = {}
@@ -361,7 +362,7 @@ def _run_custom(executors: list[Executor]) -> None:
         executor.run()
 
 
-def _make_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
+def _standardize_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
     source = dataset.data_source
     if isinstance(source, pd.DataFrame):
         csv_path = working_dir / f"{dataset.name}.csv"

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -15,9 +15,9 @@ class BenchmarkException(Exception):
 
 
 class Datatype(str, Enum):
-    tabular = "tabular"
-    time_series = "time_series"
-    natural_language = "natural_language"
+    TABULAR = "tabular"
+    TIME_SERIES = "time_series"
+    NATURAL_LANGUAGE = "natural_language"
 
 
 @dataclass

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -4,10 +4,9 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Tuple, Type, Union
+from typing import Tuple
 
 import smart_open
-from typing_extensions import Protocol
 
 logger = logging.getLogger(__name__)
 

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -4,7 +4,6 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Tuple
 
 import smart_open
 
@@ -61,7 +60,7 @@ def log(run_identifier: str, msg: str) -> None:
     logger.info(f"{run_identifier} - {msg}")
 
 
-def get_data_shape(path: str, delimiter: str = ",") -> Tuple[int, int]:
+def get_data_shape(path: str, delimiter: str = ",") -> tuple[int, int]:
     with smart_open.open(path) as f:
         reader = csv.reader(f, delimiter=delimiter)
         cols = len(next(reader))

--- a/src/gretel_trainer/benchmark/custom/datasets.py
+++ b/src/gretel_trainer/benchmark/custom/datasets.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 import pandas as pd
 

--- a/src/gretel_trainer/benchmark/custom/datasets.py
+++ b/src/gretel_trainer/benchmark/custom/datasets.py
@@ -34,8 +34,8 @@ def _to_datatype(d: Union[str, Datatype]) -> Datatype:
     if isinstance(d, Datatype):
         return d
     try:
-        return Datatype[d]
-    except KeyError:
+        return Datatype(d.lower())
+    except ValueError:
         raise BenchmarkException("Unrecognized datatype requested")
 
 

--- a/src/gretel_trainer/benchmark/custom/datasets.py
+++ b/src/gretel_trainer/benchmark/custom/datasets.py
@@ -73,6 +73,12 @@ def make_dataset(
     logger.warning(
         "`make_dataset` is deprecated and will be removed in a future release. Please use `create_dataset` instead."
     )
+
+    if not isinstance(sources, list):
+        raise BenchmarkException(
+            "Did not receive list argument to `sources`, but instead of adjusting, please use `create_dataset` instead of this deprecated function."
+        )
+
     if len(sources) > 1:
         raise BenchmarkException(
             "`make_dataset` no longer supports multiple sources. Please create separate datasets using `create_dataset`."

--- a/src/gretel_trainer/benchmark/custom/strategy.py
+++ b/src/gretel_trainer/benchmark/custom/strategy.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional
-
-from gretel_client.projects.projects import Project
+from typing import Optional
 
 from gretel_trainer.benchmark.core import BenchmarkConfig, Dataset, Timer, run_out_path
 from gretel_trainer.benchmark.custom.models import CustomModel

--- a/src/gretel_trainer/benchmark/executor.py
+++ b/src/gretel_trainer/benchmark/executor.py
@@ -1,6 +1,4 @@
 from enum import Enum
-from multiprocessing.managers import DictProxy
-from pathlib import Path
 from typing import Optional, Protocol
 
 from gretel_client.projects.models import Model

--- a/src/gretel_trainer/benchmark/gretel/datasets.py
+++ b/src/gretel_trainer/benchmark/gretel/datasets.py
@@ -94,6 +94,6 @@ class GretelDatasetRepo:
 
 def _coerce_datatype(datatype: str) -> Datatype:
     if datatype in ("tabular_numeric", "tabular_mixed"):
-        return Datatype.tabular
+        return Datatype.TABULAR
     else:
         return Datatype(datatype)

--- a/src/gretel_trainer/benchmark/gretel/datasets.py
+++ b/src/gretel_trainer/benchmark/gretel/datasets.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
-from functools import cached_property, wraps
+from functools import cached_property
 from typing import Dict, List, Optional, Tuple, Union
 
 import boto3

--- a/src/gretel_trainer/benchmark/gretel/datasets.py
+++ b/src/gretel_trainer/benchmark/gretel/datasets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from functools import cached_property
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import boto3
 from botocore import UNSIGNED
@@ -12,7 +12,7 @@ from gretel_trainer.benchmark.core import BenchmarkException, Datatype, get_data
 
 
 class GretelDataset:
-    def __init__(self, name: str, datatype: Datatype, tags: List[str]):
+    def __init__(self, name: str, datatype: Datatype, tags: list[str]):
         self.name = name
         self.datatype = datatype
         self.tags = tags
@@ -30,7 +30,7 @@ class GretelDataset:
         return self._shape[1]
 
     @cached_property
-    def _shape(self) -> Tuple[int, int]:
+    def _shape(self) -> tuple[int, int]:
         return get_data_shape(self.data_source)
 
     def __repr__(self) -> str:
@@ -52,8 +52,8 @@ class GretelDatasetRepo:
     def list_datasets(
         self,
         datatype: Optional[Union[Datatype, str]] = None,
-        tags: Optional[List[str]] = None,
-    ) -> List[GretelDataset]:
+        tags: Optional[list[str]] = None,
+    ) -> list[GretelDataset]:
         matches = list(self.manifest.values())
         if datatype is not None:
             matches = [dataset for dataset in matches if dataset.datatype == datatype]
@@ -71,14 +71,14 @@ class GretelDatasetRepo:
         except KeyError:
             raise BenchmarkException(f"No dataset exists with name {name}")
 
-    def list_tags(self) -> List[str]:
+    def list_tags(self) -> list[str]:
         unique_tags = set()
         for dataset in self.manifest.values():
             for tag in dataset.tags:
                 unique_tags.add(tag)
         return list(unique_tags)
 
-    def _read_manifest(self) -> Dict[str, GretelDataset]:
+    def _read_manifest(self) -> dict[str, GretelDataset]:
         response = self.s3.get_object(Bucket=self.bucket, Key="manifest.json")
         data = response["Body"].read()
         manifest = json.loads(data)["datasets"]

--- a/src/gretel_trainer/benchmark/gretel/datasets_backwards_compatibility.py
+++ b/src/gretel_trainer/benchmark/gretel/datasets_backwards_compatibility.py
@@ -1,0 +1,37 @@
+# This module exclusively contains deprecated functions that only exist for backwards compatibility
+# It can be deleted completely once we fully remove these functions.
+
+import logging
+from typing import Optional, Union
+
+from gretel_trainer.benchmark import Datatype
+from gretel_trainer.benchmark.gretel.datasets import GretelDataset, GretelDatasetRepo
+
+logger = logging.getLogger(__name__)
+
+
+def get_gretel_dataset(name: str) -> GretelDataset:
+    _deprecation_warning("get_gretel_dataset", "get_dataset")
+    repo = GretelDatasetRepo()
+    return repo.get_dataset(name)
+
+
+def list_gretel_datasets(
+    datatype: Optional[Union[Datatype, str]] = None, tags: Optional[list[str]] = None
+) -> list[GretelDataset]:
+    _deprecation_warning("list_gretel_datasets", "list_datasets")
+    repo = GretelDatasetRepo()
+    return repo.list_datasets(datatype, tags)
+
+
+def list_gretel_dataset_tags() -> list[str]:
+    _deprecation_warning("list_gretel_dataset_tags", "list_tags")
+    repo = GretelDatasetRepo()
+    return repo.list_tags()
+
+
+def _deprecation_warning(old: str, new: str) -> None:
+    logger.warning(
+        f"`{old}` as a freestanding function is deprecated, and will be removed in a future release. "
+        f"To avoid this warning message, going forward you should create a `GretelDatasetRepo` instance and call the `{new}` method."
+    )

--- a/src/gretel_trainer/benchmark/gretel/models.py
+++ b/src/gretel_trainer/benchmark/gretel/models.py
@@ -1,7 +1,7 @@
 import copy
 from inspect import isclass
 from pathlib import Path
-from typing import Dict, Optional, Type, Union, cast
+from typing import Optional, Type, Union, cast
 
 from gretel_client.projects.exceptions import ModelConfigError
 from gretel_client.projects.models import read_model_config
@@ -10,7 +10,7 @@ import gretel_trainer
 from gretel_trainer import models
 from gretel_trainer.benchmark.core import BenchmarkException, Dataset, Datatype
 
-GretelModelConfig = Union[str, Path, Dict]
+GretelModelConfig = Union[str, Path, dict]
 
 
 TRAINER_MODEL_TYPE_CONSTRUCTORS = {

--- a/src/gretel_trainer/benchmark/gretel/models.py
+++ b/src/gretel_trainer/benchmark/gretel/models.py
@@ -54,7 +54,7 @@ class GretelModel:
         elif self.model_key == "gpt_x":
             return (
                 dataset.column_count == 1
-                and dataset.datatype == Datatype.natural_language
+                and dataset.datatype == Datatype.NATURAL_LANGUAGE
             )
         else:
             return True

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -1,12 +1,10 @@
 import copy
 import gzip
-import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional
 
 import requests
 from gretel_client.projects.jobs import (
-    ACTIVE_STATES,
     END_STATES,
     Job,
     RunnerMode,
@@ -20,7 +18,6 @@ from gretel_trainer.benchmark.core import (
     BenchmarkConfig,
     BenchmarkException,
     Dataset,
-    log,
     run_out_path,
 )
 from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfig

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -4,12 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
-from gretel_client.projects.jobs import (
-    END_STATES,
-    Job,
-    RunnerMode,
-    Status,
-)
+from gretel_client.projects.jobs import END_STATES, Job, RunnerMode, Status
 from gretel_client.projects.models import Model, read_model_config
 from gretel_client.projects.projects import Project
 from gretel_client.projects.records import RecordHandler

--- a/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional
-
-from gretel_client.projects.projects import Project
+from typing import Optional
 
 from gretel_trainer import Trainer
 from gretel_trainer.benchmark.core import (

--- a/src/gretel_trainer/benchmark/sdk_extras.py
+++ b/src/gretel_trainer/benchmark/sdk_extras.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import smart_open
 from gretel_client.projects.jobs import (
@@ -33,7 +33,7 @@ def run_evaluate(
     evaluate_model: Model,
     run_identifier: str,
     wait: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Calling this in lieu of submit_cloud() is supposed to avoid
     # artifact upload. Doesn't work for more recent client versions!
     evaluate_model.submit(runner_mode=RunnerMode.CLOUD)
@@ -71,7 +71,7 @@ def _finished(status: Status) -> bool:
     return status in END_STATES
 
 
-def _cautiously_refresh_status(job: Job, attempts: int) -> Tuple[Status, int]:
+def _cautiously_refresh_status(job: Job, attempts: int) -> tuple[Status, int]:
     try:
         job.refresh()
         attempts = 0

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -256,7 +256,7 @@ def test_gptx_skips_too_many_columns(working_dir, project):
         data={"english": ["hello", "world"], "spanish": ["hola", "mundo"]}
     )
     dataset = make_dataset(
-        two_columns, datatype=Datatype.natural_language, name="skippy"
+        two_columns, datatype=Datatype.NATURAL_LANGUAGE, name="skippy"
     )
 
     comparison = compare(
@@ -271,7 +271,7 @@ def test_gptx_skips_too_many_columns(working_dir, project):
 
 def test_gptx_skips_non_natural_language_datatype(working_dir, project):
     tabular = pd.DataFrame(data={"foo": [1, 2, 3]})
-    dataset = make_dataset(tabular, datatype=Datatype.tabular, name="skippy")
+    dataset = make_dataset(tabular, datatype=Datatype.TABULAR, name="skippy")
 
     comparison = compare(
         datasets=[dataset],
@@ -285,7 +285,7 @@ def test_gptx_skips_non_natural_language_datatype(working_dir, project):
 
 def test_lstm_skips_datasets_with_over_150_columns(working_dir, project):
     jumbo = pd.DataFrame(columns=list(range(151)))
-    dataset = make_dataset(jumbo, datatype=Datatype.tabular, name="skippy")
+    dataset = make_dataset(jumbo, datatype=Datatype.TABULAR, name="skippy")
 
     comparison = compare(
         datasets=[dataset],

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -13,7 +13,7 @@ from gretel_trainer.benchmark import (
     GretelGPTX,
     GretelLSTM,
     compare,
-    make_dataset,
+    create_dataset,
 )
 from tests.benchmark.mocks import (
     DoNothingModel,
@@ -58,7 +58,7 @@ def test_run_with_custom_csv_dataset(working_dir, project, evaluate_report_path,
     with tempfile.NamedTemporaryFile() as f:
         df.to_csv(f.name, index=False)
 
-        dataset = make_dataset(f.name, datatype="tabular", name="pets")
+        dataset = create_dataset(f.name, datatype="tabular", name="pets")
 
         comparison = compare(
             datasets=[dataset],
@@ -86,7 +86,7 @@ def test_run_with_custom_psv_dataset(working_dir, project, evaluate_report_path,
     with tempfile.NamedTemporaryFile() as f:
         df.to_csv(f.name, sep="|", index=False)
 
-        dataset = make_dataset(f.name, datatype="tabular", name="pets", delimiter="|")
+        dataset = create_dataset(f.name, datatype="tabular", name="pets", delimiter="|")
 
         comparison = compare(
             datasets=[dataset],
@@ -113,7 +113,7 @@ def test_run_with_custom_dataframe_dataset(
     evaluate_model.get_artifact_link.return_value = evaluate_report_path
     project.create_model_obj.side_effect = [evaluate_model]
 
-    dataset = make_dataset(df, datatype="tabular", name="pets")
+    dataset = create_dataset(df, datatype="tabular", name="pets")
 
     comparison = compare(
         datasets=[dataset],
@@ -235,7 +235,7 @@ def test_custom_gretel_model_configs_do_not_overwrite_each_other(
     )
     project.create_model_obj.return_value = model
 
-    pets = make_dataset(df, datatype="tabular", name="pets")
+    pets = create_dataset(df, datatype="tabular", name="pets")
 
     comparison = compare(
         datasets=[iris, pets],
@@ -255,7 +255,7 @@ def test_gptx_skips_too_many_columns(working_dir, project):
     two_columns = pd.DataFrame(
         data={"english": ["hello", "world"], "spanish": ["hola", "mundo"]}
     )
-    dataset = make_dataset(
+    dataset = create_dataset(
         two_columns, datatype=Datatype.NATURAL_LANGUAGE, name="skippy"
     )
 
@@ -271,7 +271,7 @@ def test_gptx_skips_too_many_columns(working_dir, project):
 
 def test_gptx_skips_non_natural_language_datatype(working_dir, project):
     tabular = pd.DataFrame(data={"foo": [1, 2, 3]})
-    dataset = make_dataset(tabular, datatype=Datatype.TABULAR, name="skippy")
+    dataset = create_dataset(tabular, datatype=Datatype.TABULAR, name="skippy")
 
     comparison = compare(
         datasets=[dataset],
@@ -285,7 +285,7 @@ def test_gptx_skips_non_natural_language_datatype(working_dir, project):
 
 def test_lstm_skips_datasets_with_over_150_columns(working_dir, project):
     jumbo = pd.DataFrame(columns=list(range(151)))
-    dataset = make_dataset(jumbo, datatype=Datatype.TABULAR, name="skippy")
+    dataset = create_dataset(jumbo, datatype=Datatype.TABULAR, name="skippy")
 
     comparison = compare(
         datasets=[dataset],

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -9,7 +9,6 @@ import pytest
 from gretel_client.projects.jobs import Status
 
 from gretel_trainer.benchmark import (
-    Comparison,
     Datatype,
     GretelGPTX,
     GretelLSTM,

--- a/tests/benchmark/test_custom_datasets.py
+++ b/tests/benchmark/test_custom_datasets.py
@@ -2,29 +2,29 @@ import tempfile
 
 import pytest
 
-from gretel_trainer.benchmark import Datatype, make_dataset
+from gretel_trainer.benchmark import Datatype, create_dataset
 from gretel_trainer.benchmark.core import BenchmarkException
 
 
-def test_making_good_datasets(df):
-    str_datatype = make_dataset(df, datatype="tabular", name="via_str")
-    capital_str_datatype = make_dataset(df, datatype="TABULAR", name="via_str")
-    enum_datatype = make_dataset(df, datatype=Datatype.TABULAR, name="via_str")
+def test_creating_good_datasets(df):
+    str_datatype = create_dataset(df, datatype="tabular", name="via_str")
+    capital_str_datatype = create_dataset(df, datatype="TABULAR", name="via_str")
+    enum_datatype = create_dataset(df, datatype=Datatype.TABULAR, name="via_str")
     with tempfile.NamedTemporaryFile() as f:
         df.to_csv(f.name, index=False)
-        file_source = make_dataset(f.name, datatype="tabular", name="from_file")
+        file_source = create_dataset(f.name, datatype="tabular", name="from_file")
 
     for dataset in [str_datatype, capital_str_datatype, enum_datatype, file_source]:
         assert dataset.row_count == 3
         assert dataset.column_count == 2
 
 
-def test_making_bad_datasets(df):
+def test_creating_bad_datasets(df):
     with pytest.raises(BenchmarkException):
-        make_dataset([1, 2, 3], datatype="tabular", name="nope")  # type:ignore
+        create_dataset([1, 2, 3], datatype="tabular", name="nope")  # type:ignore
 
     with pytest.raises(BenchmarkException):
-        make_dataset("nonexistent.csv", datatype="tabular", name="nope")
+        create_dataset("nonexistent.csv", datatype="tabular", name="nope")
 
     with pytest.raises(BenchmarkException):
-        make_dataset(df, datatype="nonsense", name="nope")
+        create_dataset(df, datatype="nonsense", name="nope")

--- a/tests/benchmark/test_custom_datasets.py
+++ b/tests/benchmark/test_custom_datasets.py
@@ -8,12 +8,13 @@ from gretel_trainer.benchmark.core import BenchmarkException
 
 def test_making_good_datasets(df):
     str_datatype = make_dataset(df, datatype="tabular", name="via_str")
-    enum_datatype = make_dataset(df, datatype=Datatype.tabular, name="via_str")
+    capital_str_datatype = make_dataset(df, datatype="TABULAR", name="via_str")
+    enum_datatype = make_dataset(df, datatype=Datatype.TABULAR, name="via_str")
     with tempfile.NamedTemporaryFile() as f:
         df.to_csv(f.name, index=False)
         file_source = make_dataset(f.name, datatype="tabular", name="from_file")
 
-    for dataset in [str_datatype, enum_datatype, file_source]:
+    for dataset in [str_datatype, capital_str_datatype, enum_datatype, file_source]:
         assert dataset.row_count == 3
         assert dataset.column_count == 2
 

--- a/tests/benchmark/test_gretel_datasets_repo.py
+++ b/tests/benchmark/test_gretel_datasets_repo.py
@@ -13,7 +13,7 @@ def test_repo_list_datasets(repo):
 
     # querying by datatype, using enum or string
     tabular_datasets = repo.list_datasets(datatype="tabular")
-    tabular_enum_datasets = repo.list_datasets(datatype=Datatype.tabular)
+    tabular_enum_datasets = repo.list_datasets(datatype=Datatype.TABULAR)
     assert len(tabular_datasets) > 0
     assert len(tabular_datasets) == len(tabular_enum_datasets)
 


### PR DESCRIPTION
This PR includes changes to merge into the `b2` branch (not `main` yet!) that will ease users' transition from Benchmark v1 to v2 once we fully merge and release v2. It does not make that upgrade **fully** backwards compatible—there are still some breaking changes—but it should at least be a little smoother.

Since several people are already running Benchmark from the `b2` branch, I'll describe the changes in this PR from both perspectives. The sections below present the user-facing changes from `[section header]` to `[this branch]`; in other words, if we were to merge this PR _and_ merge b2 branch into main _and_ run a release of Trainer, these are the changes you'd have to address to start using the officially released Benchmark, depending on what you're using today.

### v1 / main branch / any Trainer version installed from pypi

- `Datatype.TABULAR_NUMERIC` and `Datatype.TABULAR_MIXED` are removed and will raise exceptions if you attempt to use them. You must change to `Datatype.TABULAR`.
- If you're passing a list of multiple sources to `make_dataset`, an exception will be raised.

(Everything else from v1 should work but start logging deprecation warnings where appropriate.)

### b2 branch

- Datatype enum variants should be capitalized, e.g. `Datatype.TABULAR` instead of `Datatype.tabular`. (I decided the change to lowercase variants on b2 branch was a mistake; capitalized enum variants are more pythonic.)
- Change `make_dataset` to `create_dataset`. (We want to keep the original signature of `make_dataset` and deprecate the function, instead of aggressively changing its signature completely.)