### PR TITLE
Chunked independent synthetics preprocessing

### DIFF
--- a/src/gretel_trainer/relational/strategies/independent.py
+++ b/src/gretel_trainer/relational/strategies/independent.py
@@ -50,9 +50,10 @@ class IndependentStrategy:
             all_columns = rel_data.get_table_columns(table)
             use_columns = [col for col in all_columns if col not in columns_to_drop]
 
-            rel_data.get_table_data(table, usecols=use_columns).to_csv(
-                path, index=False
-            )
+            pd.DataFrame(columns=use_columns).to_csv(path, index=False)
+            source_path = rel_data.get_table_source(table)
+            for chunk in pd.read_csv(source_path, usecols=use_columns, chunksize=10_000):
+                chunk.to_csv(path, index=False, mode="a", header=False)
 
         return table_paths
 


### PR DESCRIPTION
For independent synthetics, the data source we use for the model is identical to the source data except PK and FK columns are removed. Now that we have source data stored on disk instead of in memory, this small code block seemed annoying—read the whole dataframe (minus key columns) into memory only to write it right back out to CSV? Blegh.

This change at least limits the memory usage by reading and writing in chunks.

I extracted these two basic implementations and ran an experiment with tracemalloc using a 400MB CSV file. Using the previous approach, traced memory peaked at 977,813,835. When using chunks, traced memory peaked at 232,618,553.

There may be some future improvements to this (and other areas of the code) leveraging Dask, but that requires more research and testing. (In fact, a naive read-all-and-write with Dask performs worse than both these approaches, perhaps due to the overhead of Dask launching multiple workers? Dask would probably prove more beneficial with an even larger source file, one that could not fit into memory all at once.) The changes here seem like a quick enough win worth landing on their own.