### PR TITLE
fix: unit test errors on new mac m2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ df = model.generate()
 
 ## Development
 
+Setup environment and install dependencies.
+
+```sh
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
 - Run tests via `make test`
 - Run type-checking (limited coverage) via `make type`
 

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -44,7 +44,7 @@ def project():
 
 
 def _rel_data_connector(name) -> Connector:
-    con = sqlite3.connect(f"file:{name}?mode=memory&cache=shared")
+    con = sqlite3.connect(f"file:{name}?mode=memory&cache=shared", uri=True)
     cur = con.cursor()
     with open(EXAMPLE_DBS / f"{name}.sql") as f:
         cur.executescript(f.read())


### PR DESCRIPTION
A large portion of the unit tests were failing for me with a fresh clone of this repository on a brand new m2 macbook. Upon further digging I was able to identify sqlite3.connect as the issue. Specifically it wasn't honoring the uri params passed in the connection string and so it was creating a db on disk rather than an in memory shared db. This caused unit tests to throw errors.

ref: https://stackoverflow.com/questions/62502827/python-how-to-connect-sqlalchemy-to-existing-database-in-memory