### PR TITLE
fix: nested json table string length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "no_mock_suffix",
+]

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -813,19 +813,14 @@ class RelationalData:
                 "foreign_keys": foreign_keys,
                 "is_invented_table": self._is_invented(table),
             }
-            if (
-                self.is_producer_of_invented_tables(table)
-                and (producer_metadata := self.get_producer_metadata(table)) is not None
-            ):
+            if (producer_metadata := self.get_producer_metadata(table)) is not None:
                 table_metadata["invented_table_details"] = {
                     "table_type": "producer",
                     "json_to_table_mappings": producer_metadata.table_name_mappings,
                 }
             elif (
-                self._is_invented(table)
-                and (invented_table_metadata := self.get_invented_table_metadata(table))
-                is not None
-            ):
+                invented_table_metadata := self.get_invented_table_metadata(table)
+            ) is not None:
                 table_metadata["invented_table_details"] = {
                     "table_type": "invented",
                     "json_breadcrumb_path": invented_table_metadata.json_breadcrumb_path,

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -813,22 +813,23 @@ class RelationalData:
                 "foreign_keys": foreign_keys,
                 "is_invented_table": self._is_invented(table),
             }
-            if self.is_producer_of_invented_tables(table):
-                table_metadata["invented_table_details"] = {}
-                table_metadata["invented_table_details"]["table_type"] = "producer"
-                producer_metadata = self.get_producer_metadata(table)
-                if producer_metadata is not None:
-                    table_metadata["invented_table_details"][
-                        "json_to_table_mappings"
-                    ] = producer_metadata.table_name_mappings
-            elif self._is_invented(table):
-                table_metadata["invented_table_details"] = {}
-                table_metadata["invented_table_details"]["table_type"] = "invented"
-                invented_table_metadata = self.get_invented_table_metadata(table)
-                if invented_table_metadata is not None:
-                    table_metadata["invented_table_details"][
-                        "json_breadcrumb_path"
-                    ] = invented_table_metadata.json_breadcrumb_path
+            if (
+                self.is_producer_of_invented_tables(table)
+                and (producer_metadata := self.get_producer_metadata(table)) is not None
+            ):
+                table_metadata["invented_table_details"] = {
+                    "table_type": "producer",
+                    "json_to_table_mappings": producer_metadata.table_name_mappings,
+                }
+            elif (
+                self._is_invented(table)
+                and (invented_table_metadata := self.get_invented_table_metadata(table))
+                is not None
+            ):
+                table_metadata["invented_table_details"] = {
+                    "table_type": "invented",
+                    "json_breadcrumb_path": invented_table_metadata.json_breadcrumb_path,
+                }
             tables[table] = table_metadata
 
         return {

--- a/src/gretel_trainer/relational/core.py
+++ b/src/gretel_trainer/relational/core.py
@@ -806,13 +806,31 @@ class RelationalData:
                         "parent_columns": key.parent_columns,
                     }
                 )
-            tables[table] = {
+            table_metadata = {
                 "column_count": len(self.get_table_columns(table)),
                 "primary_key": self.get_primary_key(table),
                 "foreign_key_count": this_table_foreign_key_count,
                 "foreign_keys": foreign_keys,
                 "is_invented_table": self._is_invented(table),
             }
+            if self.is_producer_of_invented_tables(table):
+                table_metadata["invented_table_details"] = {}
+                table_metadata["invented_table_details"]["table_type"] = "producer"
+                producer_metadata = self.get_producer_metadata(table)
+                if producer_metadata is not None:
+                    table_metadata["invented_table_details"][
+                        "json_to_table_mappings"
+                    ] = producer_metadata.table_name_mappings
+            elif self._is_invented(table):
+                table_metadata["invented_table_details"] = {}
+                table_metadata["invented_table_details"]["table_type"] = "invented"
+                invented_table_metadata = self.get_invented_table_metadata(table)
+                if invented_table_metadata is not None:
+                    table_metadata["invented_table_details"][
+                        "json_breadcrumb_path"
+                    ] = invented_table_metadata.json_breadcrumb_path
+            tables[table] = table_metadata
+
         return {
             "foreign_key_count": total_foreign_key_count,
             "max_depth": max_depth,

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -125,9 +125,7 @@ def generate_unique_table_name(s: str):
 
 
 def make_suffix():
-    # Dropping hyphens to save on space since max table/filename length is 128 and we do not need to comply with RFC 4122
-    drop_hyphens = str(uuid4()).split("-")
-    return "".join(drop_hyphens)
+    return uuid4().hex
 
 
 def jsonencode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:

--- a/src/gretel_trainer/relational/json.py
+++ b/src/gretel_trainer/relational/json.py
@@ -120,11 +120,12 @@ def sanitize_str(s):
     sanitized_str = "-".join(re.findall(r"[a-zA-Z_0-9]+", s))
     # Generate suffix from original string, in case of sanitized_str collision
     unique_suffix = make_suffix(s)
-    return f"{sanitized_str}-{unique_suffix}"
+    # Max length for a filename is 128 chars
+    return f"{sanitized_str[:100]}-{unique_suffix}"
 
 
 def make_suffix(s):
-    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:10]
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
 
 
 def jsonencode(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -25,8 +25,14 @@ def static_suffix(request):
         yield
         return
     with patch("gretel_trainer.relational.json.make_suffix") as make_suffix:
-        make_suffix.return_value = "sfx"
+        # Each call to make_suffix must be unique or there will be table collisions
+        make_suffix.side_effect = [f"sfx{i}" for i in range(1, 50)]
         yield
+
+
+# Doesn't work well as a fixture due to the need for an input param
+def get_invented_table_suffix(make_suffix_execution_number: int):
+    return f"invented_sfx{str(make_suffix_execution_number)}"
 
 
 @pytest.fixture()

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -82,27 +82,27 @@ def tmpfile():
 
 
 @pytest.fixture()
-def pets(tmpdir):
+def pets(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("pets").extract(storage_dir=tmpdir)
 
 
 @pytest.fixture()
-def ecom(tmpdir):
+def ecom(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("ecom").extract(storage_dir=tmpdir)
 
 
 @pytest.fixture()
-def mutagenesis(tmpdir):
+def mutagenesis(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("mutagenesis").extract(storage_dir=tmpdir)
 
 
 @pytest.fixture()
-def tpch(tmpdir):
+def tpch(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("tpch").extract(storage_dir=tmpdir)
 
 
 @pytest.fixture()
-def art(tmpdir):
+def art(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("art").extract(storage_dir=tmpdir)
 
 
@@ -112,7 +112,7 @@ def documents(tmpdir) -> Generator[RelationalData, None, None]:
 
 
 @pytest.fixture()
-def trips(tmpdir):
+def trips(tmpdir) -> Generator[RelationalData, None, None]:
     with tempfile.NamedTemporaryFile() as tmpfile:
         data = pd.DataFrame(
             data={

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -20,7 +20,10 @@ def extended_sdk():
 
 
 @pytest.fixture(autouse=True)
-def static_suffix():
+def static_suffix(request):
+    if "no_mock_suffix" in request.keywords:
+        yield
+        return
     with patch("gretel_trainer.relational.json.make_suffix") as make_suffix:
         make_suffix.return_value = "sfx"
         yield

--- a/tests/relational/conftest.py
+++ b/tests/relational/conftest.py
@@ -1,6 +1,8 @@
+import itertools
 import sqlite3
 import tempfile
 from pathlib import Path
+from typing import Generator
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -26,13 +28,13 @@ def static_suffix(request):
         return
     with patch("gretel_trainer.relational.json.make_suffix") as make_suffix:
         # Each call to make_suffix must be unique or there will be table collisions
-        make_suffix.side_effect = [f"sfx{i}" for i in range(1, 50)]
-        yield
+        make_suffix.side_effect = itertools.count(start=1)
+        yield make_suffix
 
 
 # Doesn't work well as a fixture due to the need for an input param
 def get_invented_table_suffix(make_suffix_execution_number: int):
-    return f"invented_sfx{str(make_suffix_execution_number)}"
+    return f"invented_{str(make_suffix_execution_number)}"
 
 
 @pytest.fixture()
@@ -105,7 +107,7 @@ def art(tmpdir):
 
 
 @pytest.fixture()
-def documents(tmpdir):
+def documents(tmpdir) -> Generator[RelationalData, None, None]:
     yield _rel_data_connector("documents").extract(storage_dir=tmpdir)
 
 

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -59,6 +59,7 @@ def test_backup_relational_data_with_json(documents):
                 invented_table_metadata={
                     "invented_root_table_name": purchases_root_invented_table,
                     "original_table_name": "purchases",
+                    "json_breadcrumb_path": "purchases",
                     "empty": False,
                 },
             ),
@@ -67,6 +68,7 @@ def test_backup_relational_data_with_json(documents):
                 invented_table_metadata={
                     "invented_root_table_name": purchases_root_invented_table,
                     "original_table_name": "purchases",
+                    "json_breadcrumb_path": "purchases^data>years",
                     "empty": False,
                 },
             ),

--- a/tests/relational/test_backup.py
+++ b/tests/relational/test_backup.py
@@ -11,6 +11,7 @@ from gretel_trainer.relational.backup import (
     BackupSyntheticsTrain,
     BackupTransformsTrain,
 )
+from tests.relational.conftest import get_invented_table_suffix
 
 
 def test_backup_relational_data(trips):
@@ -37,31 +38,34 @@ def test_backup_relational_data(trips):
 
 
 def test_backup_relational_data_with_json(documents):
+    purchases_root_invented_table = f"purchases_{get_invented_table_suffix(1)}"
+    purchases_data_years_invented_table = f"purchases_{get_invented_table_suffix(2)}"
+
     expected = BackupRelationalData(
         tables={
             "users": BackupRelationalDataTable(primary_key=["id"]),
             "purchases": BackupRelationalDataTable(
                 primary_key=["id"],
                 producer_metadata={
-                    "invented_root_table_name": "purchases-sfx",
+                    "invented_root_table_name": purchases_root_invented_table,
                     "table_name_mappings": {
-                        "purchases": "purchases-sfx",
-                        "purchases^data>years": "purchases-data-years-sfx",
+                        "purchases": purchases_root_invented_table,
+                        "purchases^data>years": purchases_data_years_invented_table,
                     },
                 },
             ),
-            "purchases-sfx": BackupRelationalDataTable(
+            purchases_root_invented_table: BackupRelationalDataTable(
                 primary_key=["id", "~PRIMARY_KEY_ID~"],
                 invented_table_metadata={
-                    "invented_root_table_name": "purchases-sfx",
+                    "invented_root_table_name": purchases_root_invented_table,
                     "original_table_name": "purchases",
                     "empty": False,
                 },
             ),
-            "purchases-data-years-sfx": BackupRelationalDataTable(
+            purchases_data_years_invented_table: BackupRelationalDataTable(
                 primary_key=["~PRIMARY_KEY_ID~"],
                 invented_table_metadata={
-                    "invented_root_table_name": "purchases-sfx",
+                    "invented_root_table_name": purchases_root_invented_table,
                     "original_table_name": "purchases",
                     "empty": False,
                 },
@@ -72,19 +76,19 @@ def test_backup_relational_data_with_json(documents):
             BackupForeignKey(
                 table="payments",
                 constrained_columns=["purchase_id"],
-                referred_table="purchases-sfx",
+                referred_table=purchases_root_invented_table,
                 referred_columns=["id"],
             ),
             BackupForeignKey(
-                table="purchases-sfx",
+                table=purchases_root_invented_table,
                 constrained_columns=["user_id"],
                 referred_table="users",
                 referred_columns=["id"],
             ),
             BackupForeignKey(
-                table="purchases-data-years-sfx",
+                table=purchases_data_years_invented_table,
                 constrained_columns=["purchases~id"],
-                referred_table="purchases-sfx",
+                referred_table=purchases_root_invented_table,
                 referred_columns=["~PRIMARY_KEY_ID~"],
             ),
         ],

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -212,7 +212,6 @@ def test_invented_json_column_names_documents(documents):
 
 def test_invented_json_column_names_bball(bball):
     # If the source table does not have a primary key defined, one is created on the root invented table
-    # (bball_teams_invented_table is the root invented table)
     assert bball.get_table_columns(bball_root_invented_table) == [
         "~PRIMARY_KEY_ID~",
         "name",
@@ -1009,7 +1008,7 @@ def test_all_tables_are_present_in_debug_summary(documents):
 
 
 @pytest.mark.no_mock_suffix
-def test_invented_table_names_contain_uuid(documents):
+def test_invented_table_names_contain_uuid(documents: RelationalData):
     regex = re.compile(r"purchases_invented_[a-fA-F0-9]{32}")
     tables = documents.list_all_tables(Scope.INVENTED)
     assert len(tables) == 2

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -976,6 +976,13 @@ def test_all_tables_are_present_in_debug_summary(documents):
                     }
                 ],
                 "is_invented_table": False,
+                "invented_table_details": {
+                    "table_type": "producer",
+                    "json_to_table_mappings": {
+                        "purchases": purchases_root_invented_table,
+                        "purchases^data>years": purchases_data_years_invented_table,
+                    },
+                },
             },
             purchases_root_invented_table: {
                 "column_count": 6,
@@ -989,6 +996,10 @@ def test_all_tables_are_present_in_debug_summary(documents):
                     }
                 ],
                 "is_invented_table": True,
+                "invented_table_details": {
+                    "table_type": "invented",
+                    "json_breadcrumb_path": "purchases",
+                },
             },
             purchases_data_years_invented_table: {
                 "column_count": 4,
@@ -1002,6 +1013,10 @@ def test_all_tables_are_present_in_debug_summary(documents):
                     }
                 ],
                 "is_invented_table": True,
+                "invented_table_details": {
+                    "table_type": "invented",
+                    "json_breadcrumb_path": "purchases^data>years",
+                },
             },
         },
     }

--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -1009,7 +1009,7 @@ def test_all_tables_are_present_in_debug_summary(documents):
 
 
 @pytest.mark.no_mock_suffix
-def test_invented_table_names_contain_uuid(documents: RelationalData):
+def test_invented_table_names_contain_uuid(documents):
     regex = re.compile(r"purchases_invented_[a-fA-F0-9]{32}")
     tables = documents.list_all_tables(Scope.INVENTED)
     assert len(tables) == 2

--- a/tests/relational/test_train_synthetics.py
+++ b/tests/relational/test_train_synthetics.py
@@ -5,6 +5,7 @@ import pytest
 
 from gretel_trainer.relational.core import MultiTableException
 from gretel_trainer.relational.multi_table import MultiTable
+from tests.relational.conftest import get_invented_table_suffix
 
 
 # The assertions in this file are concerned with setting up the synthetics train
@@ -209,11 +210,14 @@ def test_train_synthetics_models_for_dbs_with_invented_tables(documents, tmpdir)
     mt = MultiTable(documents, project_display_name=tmpdir)
     mt.train_synthetics()
 
+    purchases_root_invented_table = f"purchases_{get_invented_table_suffix(1)}"
+    purchases_data_years_invented_table = f"purchases_{get_invented_table_suffix(2)}"
+
     assert set(mt._synthetics_train.models.keys()) == {
         "users",
         "payments",
-        "purchases-sfx",
-        "purchases-data-years-sfx",
+        purchases_root_invented_table,
+        purchases_data_years_invented_table,
     }
 
 


### PR DESCRIPTION
In cases where we are parsing nested json with lengthy key strings the combination of key strings in the breadcrumb based table name string would result in an error when trying to train the model due to a maximum json filename length of 128 chars. Here we utilize the already existing make_suffix function (which ensures no sanitized_str collisions) and we truncate the length of the table name to ensure we do not exceed the 128 char limit.