### PR TITLE
Fix RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-docutils==0.17.1
-jinja2<3.1
 m2r
+Sphinx==6.2.1
+docutils==0.18.1
 mistune==0.8.4
-sphinx-rtd-theme
-sphinx==3.0.3
+sphinx-rtd-theme==1.2.2
+-r ../requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,5 @@ Sphinx==6.2.1
 docutils==0.18.1
 mistune==0.8.4
 sphinx-rtd-theme==1.2.2
+pyyaml==6.0.1
 -r ../requirements.txt


### PR DESCRIPTION
What it looked like before (which matches the [live docs](https://trainer.docs.gretel.ai/en/latest/models.html))
<img width="1184" alt="Screenshot 2023-07-19 at 11 25 33 AM" src="https://github.com/gretelai/trainer/assets/2601844/4fd9637d-9a0b-4b23-aeb9-5ecee4cecaf6">

what it looks like after:
<img width="1223" alt="Screenshot 2023-07-19 at 1 02 46 PM" src="https://github.com/gretelai/trainer/assets/2601844/afda0af2-fec1-4fc1-84af-9a6d277f43de">

To fix we had to:
1. First, add in `../requirements.txt`; the build couldn't pull in the deps from this repo because the docs requirements.txt wasn't installing it. This is the core problem with why `Models` and others were blank, and can be seen in the build logs: https://readthedocs.org/projects/gretel-trainer/builds/21339763/
2. Once we did that, we started getting some incompatibility errors due to new libraries. Thats why there's a few library bumps here. However, they're bumping to versions that align with the known-working gretel-client and gretel-synthetic libraries as well, so we aren't "praying" too much here that there won't be other problems; this combo has been shown working in other repos
3. Pin `pyyaml==6.0.1` because Dask was pulling in a `5.x` version, which has errors building locally on macos. This might not be necessary in the actual RTD build because there should be wheels for linux, but this allows us to reproduce functionality locally