### PR TITLE
Introduce Session as a job executor to support use cases other than compare.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests~=2.25
 scikit-learn~=1.0
 smart-open[s3]~=5.2
 sqlalchemy~=1.4
+typing-extensions~=4.7

--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from gretel_trainer.benchmark.comparison import compare
+from gretel_trainer.benchmark.entrypoints import compare, launch
 from gretel_trainer.benchmark.core import BenchmarkConfig, Datatype
 from gretel_trainer.benchmark.custom.datasets import create_dataset, make_dataset
 from gretel_trainer.benchmark.gretel.datasets import GretelDatasetRepo

--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from gretel_trainer.benchmark.comparison import Comparison, compare
+from gretel_trainer.benchmark.comparison import compare
 from gretel_trainer.benchmark.core import BenchmarkConfig, Datatype
 from gretel_trainer.benchmark.custom.datasets import create_dataset, make_dataset
 from gretel_trainer.benchmark.gretel.datasets import GretelDatasetRepo

--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -1,8 +1,8 @@
 import logging
 
-from gretel_trainer.benchmark.entrypoints import compare, launch
 from gretel_trainer.benchmark.core import BenchmarkConfig, Datatype
 from gretel_trainer.benchmark.custom.datasets import create_dataset, make_dataset
+from gretel_trainer.benchmark.entrypoints import compare, launch
 from gretel_trainer.benchmark.gretel.datasets import GretelDatasetRepo
 from gretel_trainer.benchmark.gretel.datasets_backwards_compatibility import (
     get_gretel_dataset,

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -1,36 +1,21 @@
 from __future__ import annotations
 
 import logging
-from concurrent.futures import Future, ThreadPoolExecutor
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Optional, Type, Union, cast
+from typing import Optional, Type, Union, cast
 
 import pandas as pd
 from gretel_client import configure_session
-from gretel_client.helpers import poll
-from gretel_client.projects import Project, create_project, search_projects
-from gretel_client.projects.jobs import Job
 
 from gretel_trainer.benchmark.core import BenchmarkConfig, BenchmarkException, Dataset
 from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
-from gretel_trainer.benchmark.custom.strategy import CustomStrategy
-from gretel_trainer.benchmark.executor import Executor
 from gretel_trainer.benchmark.gretel.datasets import GretelDataset
-from gretel_trainer.benchmark.gretel.models import GretelAuto, GretelModel
-from gretel_trainer.benchmark.gretel.strategy_sdk import GretelSDKStrategy
-from gretel_trainer.benchmark.gretel.strategy_trainer import GretelTrainerStrategy
+from gretel_trainer.benchmark.gretel.models import GretelModel
+from gretel_trainer.benchmark.session import JobSpec, Session, launch, model_name
 
 logger = logging.getLogger(__name__)
-
-ALL_REPORT_SCORES = {
-    "SQS": "synthetic_data_quality_score",
-    "FCS": "field_correlation_stability",
-    "PCS": "principal_component_stability",
-    "FDS": "field_distribution_stability",
-    "PPL": "privacy_protection_level",
-}
 
 
 DatasetTypes = Union[CustomDataset, GretelDataset]
@@ -42,304 +27,37 @@ ModelTypes = Union[
 ]
 
 
-class RunKey(tuple[str, str]):
-    RUN_IDENTIFIER_SEPARATOR = "-"
-
-    @property
-    def model_name(self) -> str:
-        return self[0]
-
-    @property
-    def dataset_name(self) -> str:
-        return self[1]
-
-    @property
-    def identifier(self) -> str:
-        """Identifier returns a flat string identifying this run.
-
-        Returns:
-            A string identifying the run.
-        """
-        return self.RUN_IDENTIFIER_SEPARATOR.join(self)
-
-    def __repr__(self) -> str:
-        return f"({self.model_name}, {self.dataset_name})"
-
-
-FutureKeyT = Union[str, RunKey]
-
-
 def compare(
     *,
     datasets: list[DatasetTypes],
     models: list[ModelTypes],
     config: Optional[BenchmarkConfig] = None,
-) -> Comparison:
-    comparison = Comparison(
-        datasets=datasets,
-        models=models,
-        config=config,
-    )
-    return comparison.prepare().execute()
+) -> Session:
+    config = config or BenchmarkConfig()
+
+    model_instances = _create_models(models)
+    _validate_compare(model_instances, datasets)
+
+    # TODO(pm): I think moving this outside of Session makes sense, so it can be configured externally
+    configure_session(api_key="prompt", cache="yes", validate=True)
+
+    config.working_dir.mkdir(exist_ok=True)
+    datasets = [
+        _standardize_dataset(dataset, config.working_dir) for dataset in datasets
+    ]
+
+    jobs = []
+    for dataset in datasets:
+        for model in model_instances:
+            jobs.append(JobSpec(dataset, model))
+
+    return launch(jobs=jobs, config=config)
 
 
-class Comparison:
-    def __init__(
-        self,
-        *,
-        datasets: list[DatasetTypes],
-        models: list[ModelTypes],
-        config: Optional[BenchmarkConfig] = None,
-    ):
-        model_instances = [
-            cast(Union[GretelModel, CustomModel], m() if isclass(m) else m)
-            for m in models
-        ]
-        self.gretel_models = [m for m in model_instances if isinstance(m, GretelModel)]
-        self.custom_models = [
-            m for m in model_instances if not isinstance(m, GretelModel)
-        ]
-
-        self.config = config or BenchmarkConfig()
-
-        _validate_setup(self.config, self.gretel_models, self.custom_models, datasets)
-
-        configure_session(api_key="prompt", cache="yes", validate=True)
-
-        self.config.working_dir.mkdir(exist_ok=True)
-        self.datasets = [
-            _standardize_dataset(dataset, self.config.working_dir)
-            for dataset in datasets
-        ]
-        self._gretel_executors: dict[RunKey, Executor] = {}
-        self._custom_executors: dict[RunKey, Executor] = {}
-        self.trainer_project_names: dict[str, str] = {}
-        self.thread_pool = ThreadPoolExecutor(5)
-        self.futures: dict[FutureKeyT, Future] = {}
-
-        self._report_scores = {
-            score_name: ALL_REPORT_SCORES[score_name]
-            for score_name in ["SQS"] + self.config.additional_report_scores
-        }
-
-    @property
-    def executors(self) -> dict[RunKey, Executor]:
-        return self._gretel_executors | self._custom_executors
-
-    def _make_project(self) -> Project:
-        display_name = self.config.project_display_name
-        if self.config.trainer:
-            display_name = f"{display_name}-evaluate"
-
-        return create_project(display_name=display_name)
-
-    def prepare(self) -> Comparison:
-        self._project = self._make_project()
-
-        _trainer_project_index = 0
-        for dataset in self.datasets:
-            # TODO: avoid upload for public datasets, when possible
-            artifact_key = _upload_dataset_to_project(
-                dataset.data_source,
-                self._project,
-                self.config.trainer,
-            )
-
-            for model in self.gretel_models:
-                self._setup_gretel_run(
-                    dataset, model, artifact_key, _trainer_project_index
-                )
-                _trainer_project_index += 1
-
-            for model in self.custom_models:
-                self._setup_custom_run(dataset, model, artifact_key)
-
-        return self
-
-    def execute(self) -> Comparison:
-        for run_key, executor in self._gretel_executors.items():
-            self.futures[run_key] = self.thread_pool.submit(_run_gretel, executor)
-
-        if len(self._custom_executors) > 0:
-            self.futures["custom"] = self.thread_pool.submit(
-                _run_custom, list(self._custom_executors.values())
-            )
-
-        return self
-
-    @property
-    def results(self) -> pd.DataFrame:
-        result_records = [self._result_dict(run_key) for run_key in self.executors]
-        return pd.DataFrame.from_records(result_records)
-
-    def export_results(self, destination: str) -> None:
-        self.results.to_csv(destination, index=False)
-
-    def wait(self) -> Comparison:
-        [future.result() for future in self.futures.values()]
-        return self
-
-    def whats_happening(self) -> dict[str, str]:
-        return {
-            str(key): self._basic_status(future) for key, future in self.futures.items()
-        }
-
-    def poll_job(self, model: str, dataset: str, action: str):
-        job = self._get_gretel_job(model, dataset, action)
-        poll(job)
-
-    def get_logs(self, model: str, dataset: str, action: str):
-        job = self._get_gretel_job(model, dataset, action)
-        return job.logs
-
-    def _get_gretel_job(self, model: str, dataset: str, action: str) -> Job:
-        run_key = RunKey((model, dataset))
-        executor = self.executors[run_key]
-        strategy = executor.strategy
-        if not isinstance(strategy, GretelSDKStrategy):
-            raise BenchmarkException("Cannot get Gretel job for non-GretelSDK runs")
-
-        if action == "train":
-            job = strategy.model
-        elif action == "generate":
-            job = strategy.record_handler
-        else:
-            raise BenchmarkException(
-                f"Unrecognized action `{action}` (must be `train` or `generate`)"
-            )
-
-        if job is None:
-            raise BenchmarkException("Gretel Job does not exist")
-
-        return job
-
-    def cleanup(self) -> None:
-        self._project.delete()
-
-        if self.config.trainer:
-            for project in search_projects(query=self.config.project_display_name):
-                project.delete()
-
-    def _result_dict(self, run_key: RunKey) -> dict[str, Any]:
-        executor = self.executors[run_key]
-        model_name, dataset_name = run_key
-
-        train_time = executor.strategy.get_train_time()
-        generate_time = executor.strategy.get_generate_time()
-
-        total_time = train_time
-        if train_time is not None and generate_time is not None:
-            total_time = train_time + generate_time
-
-        return {
-            "Input data": dataset_name,
-            "Model": model_name,
-            "DataType": executor.strategy.dataset.datatype,
-            "Rows": executor.strategy.dataset.row_count,
-            "Columns": executor.strategy.dataset.column_count,
-            "Status": executor.status.value,
-            **{
-                score_name: executor.get_report_score(score_key)
-                for score_name, score_key in self._report_scores.items()
-            },
-            "Train time (sec)": train_time,
-            "Generate time (sec)": generate_time,
-            "Total time (sec)": total_time,
-        }
-
-    def _setup_gretel_run(
-        self,
-        dataset: Dataset,
-        model: GretelModel,
-        artifact_key: Optional[str],
-        trainer_project_index: int,
-    ) -> None:
-        run_key = _make_run_key(model, dataset)
-        run_identifier = run_key.identifier
-        strategy = self._set_gretel_strategy(
-            benchmark_model=model,
-            dataset=dataset,
-            run_identifier=run_identifier,
-            trainer_project_index=trainer_project_index,
-            artifact_key=artifact_key,
-        )
-        executor = Executor(
-            strategy=strategy,
-            run_identifier=run_identifier,
-            evaluate_project=self._project,
-            config=self.config,
-        )
-        self._gretel_executors[run_key] = executor
-
-    def _setup_custom_run(
-        self,
-        dataset: Dataset,
-        model: CustomModel,
-        artifact_key: Optional[str] = None,
-    ) -> None:
-        run_key = _make_run_key(model, dataset)
-        run_identifier = run_key.identifier
-        strategy = CustomStrategy(
-            benchmark_model=model,
-            dataset=dataset,
-            run_identifier=run_identifier,
-            config=self.config,
-            artifact_key=artifact_key,
-        )
-        executor = Executor(
-            strategy=strategy,
-            run_identifier=run_identifier,
-            evaluate_project=self._project,
-            config=self.config,
-        )
-        self._custom_executors[run_key] = executor
-
-    def _basic_status(self, future: Future) -> str:
-        if future.done():
-            return "Finished"
-        elif future.cancelled():
-            return "Cancelled"
-        else:
-            return "Running"
-
-    def _set_gretel_strategy(
-        self,
-        benchmark_model: GretelModel,
-        dataset: Dataset,
-        run_identifier: str,
-        trainer_project_index: int,
-        artifact_key: Optional[str],
-    ) -> Union[GretelSDKStrategy, GretelTrainerStrategy]:
-        if self.config.trainer:
-            trainer_project_name = _trainer_project_name(
-                self.config, trainer_project_index
-            )
-            self.trainer_project_names[run_identifier] = trainer_project_name
-            return GretelTrainerStrategy(
-                benchmark_model=benchmark_model,
-                dataset=dataset,
-                run_identifier=run_identifier,
-                project_name=trainer_project_name,
-                config=self.config,
-            )
-        else:
-            return GretelSDKStrategy(
-                benchmark_model=benchmark_model,
-                dataset=dataset,
-                artifact_key=artifact_key,
-                run_identifier=run_identifier,
-                project=self._project,
-                config=self.config,
-            )
-
-
-def _run_gretel(executor: Executor) -> None:
-    executor.run()
-
-
-def _run_custom(executors: list[Executor]) -> None:
-    for executor in executors:
-        executor.run()
+def _create_models(models: list[ModelTypes]) -> list[Union[GretelModel, CustomModel]]:
+    return [
+        cast(Union[GretelModel, CustomModel], m() if isclass(m) else m) for m in models
+    ]
 
 
 def _standardize_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
@@ -359,71 +77,15 @@ def _standardize_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
     )
 
 
-def _make_run_key(model: Union[GretelModel, CustomModel], dataset: Dataset) -> RunKey:
-    return RunKey((_model_name(model), dataset.name))
-
-
-def _validate_setup(
-    config: BenchmarkConfig,
-    gretel_models: list[GretelModel],
-    custom_models: list[CustomModel],
-    all_datasets: list[DatasetTypes],
+def _validate_compare(
+    all_models: list[Union[GretelModel, CustomModel]], all_datasets: list[DatasetTypes]
 ) -> None:
     dataset_names = [d.name for d in all_datasets]
-    model_names = [_model_name(m) for m in (gretel_models + custom_models)]
+    model_names = [model_name(m) for m in all_models]
     _ensure_unique(dataset_names, "datasets")
     _ensure_unique(model_names, "models")
-
-    if config.trainer:
-        _validate_trainer_setup(gretel_models)
-    else:
-        _validate_sdk_setup(gretel_models)
 
 
 def _ensure_unique(col: list[str], kind: str) -> None:
     if len(set(col)) < len(col):
         raise BenchmarkException(f"{kind} must have unique names")
-
-
-def _validate_trainer_setup(gretel_models: list[GretelModel]) -> None:
-    unsupported_models = []
-    for model in gretel_models:
-        if model.trainer_model_type is None:
-            logger.error(
-                f"Model `{model.name}` (model key `{model.model_key}`) is not supported by Trainer. "
-                "Either remove it from this comparison, or configure this comparison to use the SDK (trainer=False)"
-            )
-            unsupported_models.append(model)
-    if len(unsupported_models) > 0:
-        raise BenchmarkException("Invalid configuration")
-
-
-def _validate_sdk_setup(gretel_models: list[GretelModel]) -> None:
-    if any(isinstance(m, GretelAuto) for m in gretel_models):
-        logger.error(
-            "GretelAuto is only supported when using Trainer. "
-            "Either remove it from this comparison, or configure this comparison to use Trainer (trainer=True)"
-        )
-        raise BenchmarkException("Invalid configuration")
-
-
-def _model_name(model: Union[GretelModel, CustomModel]) -> str:
-    if isinstance(model, GretelModel):
-        return model.name
-    else:
-        return type(model).__name__
-
-
-def _trainer_project_name(config: BenchmarkConfig, index: int) -> str:
-    prefix = config.project_display_name
-    name = f"{prefix}-{index}"
-    return name.replace("_", "-")
-
-
-def _upload_dataset_to_project(
-    source: str, project: Project, trainer: bool
-) -> Optional[str]:
-    if trainer:
-        return None
-
-    return project.upload_artifact(source)

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -42,12 +42,12 @@ def compare(
     configure_session(api_key="prompt", cache="yes", validate=True)
 
     config.working_dir.mkdir(exist_ok=True)
-    datasets = [
+    standardized_datasets = [
         _standardize_dataset(dataset, config.working_dir) for dataset in datasets
     ]
 
     jobs = []
-    for dataset in datasets:
+    for dataset in standardized_datasets:
         for model in model_instances:
             jobs.append(JobSpec(dataset, model))
 

--- a/src/gretel_trainer/benchmark/comparison.py
+++ b/src/gretel_trainer/benchmark/comparison.py
@@ -13,7 +13,8 @@ from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
 from gretel_trainer.benchmark.gretel.datasets import GretelDataset
 from gretel_trainer.benchmark.gretel.models import GretelModel
-from gretel_trainer.benchmark.session import JobSpec, Session, launch, model_name
+from gretel_trainer.benchmark.job_spec import JobSpec, model_name
+from gretel_trainer.benchmark.session import Session, launch
 
 logger = logging.getLogger(__name__)
 

--- a/src/gretel_trainer/benchmark/core.py
+++ b/src/gretel_trainer/benchmark/core.py
@@ -71,8 +71,13 @@ def run_out_path(working_dir: Path, run_identifier: str) -> Path:
     return working_dir / f"synth_{run_identifier}.csv"
 
 
-def log(run_identifier: str, msg: str) -> None:
-    logger.info(f"{run_identifier} - {msg}")
+def log(
+    run_identifier: str,
+    msg: str,
+    level: int = logging.INFO,
+    exc_info: Optional[Exception] = None,
+) -> None:
+    logger.log(level, f"{run_identifier} - {msg}", exc_info=exc_info)
 
 
 def get_data_shape(path: str, delimiter: str = ",") -> tuple[int, int]:

--- a/src/gretel_trainer/benchmark/entrypoints.py
+++ b/src/gretel_trainer/benchmark/entrypoints.py
@@ -10,22 +10,17 @@ import pandas as pd
 from gretel_client.config import get_session_config
 
 from gretel_trainer.benchmark.core import BenchmarkConfig, BenchmarkException, Dataset
-from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
-from gretel_trainer.benchmark.gretel.datasets import GretelDataset
 from gretel_trainer.benchmark.gretel.models import GretelModel
-from gretel_trainer.benchmark.job_spec import JobSpec
+from gretel_trainer.benchmark.job_spec import (
+    DatasetTypes,
+    JobSpec,
+    ModelTypes,
+    model_name,
+)
 from gretel_trainer.benchmark.session import Session
 
 logger = logging.getLogger(__name__)
-
-DatasetTypes = Union[CustomDataset, GretelDataset]
-ModelTypes = Union[
-    CustomModel,
-    Type[CustomModel],
-    GretelModel,
-    Type[GretelModel],
-]
 
 
 def compare(
@@ -37,7 +32,7 @@ def compare(
     cross_product: list[tuple[DatasetTypes, ModelTypes]] = []
 
     _ensure_unique([d.name for d in datasets], "datasets")
-    _ensure_unique([_model_name(m) for m in models], "models")
+    _ensure_unique([model_name(m) for m in models], "models")
 
     for dataset in datasets:
         for model in models:
@@ -119,12 +114,3 @@ def _standardize_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
 def _ensure_unique(col: list[str], kind: str) -> None:
     if len(set(col)) < len(col):
         raise BenchmarkException(f"{kind} must have unique names")
-
-
-def _model_name(model: ModelTypes):
-    if isinstance(model, GretelModel):
-        return model.name
-    elif isclass(model):
-        return model.__name__
-    else:
-        return type(model).__name__

--- a/src/gretel_trainer/benchmark/entrypoints.py
+++ b/src/gretel_trainer/benchmark/entrypoints.py
@@ -15,7 +15,7 @@ from gretel_trainer.benchmark.custom.models import CustomModel
 from gretel_trainer.benchmark.gretel.datasets import GretelDataset
 from gretel_trainer.benchmark.gretel.models import GretelModel
 from gretel_trainer.benchmark.job_spec import JobSpec
-from gretel_trainer.benchmark.session import Session, is_gretel_model
+from gretel_trainer.benchmark.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,7 @@ def _entrypoint(
     jobs: list[tuple[DatasetTypes, ModelTypes]],
     config: Optional[BenchmarkConfig] = None,
 ) -> Session:
+    _verify_client_config()
     config = config or BenchmarkConfig()
 
     working_dir_cleanup = lambda: None
@@ -75,10 +76,6 @@ def _entrypoint(
             )
             for dataset, model in jobs
         ]
-
-        if any(is_gretel_model(job) for job in job_specs):
-            _verify_client_config()
-
     except Exception as e:
         working_dir_cleanup()
         raise e

--- a/src/gretel_trainer/benchmark/entrypoints.py
+++ b/src/gretel_trainer/benchmark/entrypoints.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 from inspect import isclass
 from pathlib import Path
-from typing import Callable, Optional, Type, Union, cast
+from typing import Optional, Type, Union, cast
 
 import pandas as pd
 from gretel_client.config import get_session_config
@@ -14,7 +14,7 @@ from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
 from gretel_trainer.benchmark.gretel.datasets import GretelDataset
 from gretel_trainer.benchmark.gretel.models import GretelModel
-from gretel_trainer.benchmark.job_spec import JobSpec, model_name
+from gretel_trainer.benchmark.job_spec import JobSpec
 from gretel_trainer.benchmark.session import Session, is_gretel_model
 
 logger = logging.getLogger(__name__)
@@ -122,6 +122,7 @@ def _standardize_dataset(dataset: DatasetTypes, working_dir: Path) -> Dataset:
 def _ensure_unique(col: list[str], kind: str) -> None:
     if len(set(col)) < len(col):
         raise BenchmarkException(f"{kind} must have unique names")
+
 
 def _model_name(model: ModelTypes):
     if isinstance(model, GretelModel):

--- a/src/gretel_trainer/benchmark/executor.py
+++ b/src/gretel_trainer/benchmark/executor.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 from typing import Optional, Protocol
 
@@ -102,7 +103,7 @@ class Executor:
             self.strategy.train()
             self._log("training completed successfully")
         except Exception as e:
-            self._log("training failed")
+            self._log("training failed", level=logging.ERROR, exc_info=e)
             self.status = Status.FailedTrain
             self.exception = e
 
@@ -113,7 +114,9 @@ class Executor:
             self.strategy.generate()
             self._log("synthetic data generation completed successfully")
         except Exception as e:
-            self._log("synthetic data generation failed")
+            self._log(
+                "synthetic data generation failed", level=logging.ERROR, exc_info=e
+            )
             self.status = Status.FailedGenerate
             self.exception = e
 
@@ -138,7 +141,7 @@ class Executor:
             self._log("evaluation completed successfully")
             self.status = Status.Complete
         except Exception as e:
-            self._log("evaluation failed")
+            self._log("evaluation failed", level=logging.ERROR, exc_info=e)
             self.status = Status.FailedEvaluate
             self.exception = e
         finally:
@@ -147,5 +150,7 @@ class Executor:
             except:
                 pass
 
-    def _log(self, msg: str) -> None:
-        log(self.run_identifier, msg)
+    def _log(
+        self, msg: str, level: int = logging.INFO, exc_info: Optional[Exception] = None
+    ) -> None:
+        log(self.run_identifier, msg, level, exc_info)

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -16,21 +16,20 @@ from gretel_trainer.benchmark.core import (
     run_out_path,
 )
 from gretel_trainer.benchmark.gretel.models import GretelModel, GretelModelConfig
+from gretel_trainer.benchmark.job_spec import JobSpec
 from gretel_trainer.benchmark.sdk_extras import await_job
 
 
 class GretelSDKStrategy:
     def __init__(
         self,
-        benchmark_model: GretelModel,
-        dataset: Dataset,
+        job_spec: JobSpec,
         artifact_key: Optional[str],
         run_identifier: str,
         project: Project,
         config: BenchmarkConfig,
     ):
-        self.benchmark_model = benchmark_model
-        self.dataset = dataset
+        self.job_spec = job_spec
         self.artifact_key = artifact_key
         self.run_identifier = run_identifier
         self.project = project
@@ -38,6 +37,19 @@ class GretelSDKStrategy:
 
         self.model: Optional[Model] = None
         self.record_handler: Optional[RecordHandler] = None
+
+    @property
+    def dataset(self) -> Dataset:
+        return self.job_spec.dataset
+
+    @property
+    def benchmark_model(self) -> GretelModel:
+        if not isinstance(self.job_spec.model, GretelModel):
+            raise BenchmarkException(
+                "GretelSDKStrategy can only be used with GretelModel"
+            )
+
+        return self.job_spec.model
 
     def _format_model_config(self) -> GretelModelConfig:
         config = copy.deepcopy(read_model_config(self.benchmark_model.config))

--- a/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_sdk.py
@@ -23,7 +23,7 @@ from gretel_trainer.benchmark.sdk_extras import await_job
 class GretelSDKStrategy:
     def __init__(
         self,
-        job_spec: JobSpec,
+        job_spec: JobSpec[GretelModel],
         artifact_key: Optional[str],
         run_identifier: str,
         project: Project,
@@ -44,11 +44,6 @@ class GretelSDKStrategy:
 
     @property
     def benchmark_model(self) -> GretelModel:
-        if not isinstance(self.job_spec.model, GretelModel):
-            raise BenchmarkException(
-                "GretelSDKStrategy can only be used with GretelModel"
-            )
-
         return self.job_spec.model
 
     def _format_model_config(self) -> GretelModelConfig:

--- a/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
@@ -10,19 +10,18 @@ from gretel_trainer.benchmark.core import (
     run_out_path,
 )
 from gretel_trainer.benchmark.gretel.models import GretelModel
+from gretel_trainer.benchmark.job_spec import JobSpec
 
 
 class GretelTrainerStrategy:
     def __init__(
         self,
-        benchmark_model: GretelModel,
-        dataset: Dataset,
+        job_spec: JobSpec,
         run_identifier: str,
         project_name: str,
         config: BenchmarkConfig,
     ):
-        self.benchmark_model = benchmark_model
-        self.dataset = dataset
+        self.job_spec = job_spec
         self.run_identifier = run_identifier
         self.project_name = project_name
         self.config = config
@@ -30,6 +29,19 @@ class GretelTrainerStrategy:
         self.trainer: Optional[Trainer] = None
         self.train_timer: Optional[Timer] = None
         self.generate_timer: Optional[Timer] = None
+
+    @property
+    def dataset(self) -> Dataset:
+        return self.job_spec.dataset
+
+    @property
+    def benchmark_model(self) -> GretelModel:
+        if not isinstance(self.job_spec.model, GretelModel):
+            raise BenchmarkException(
+                "GretelSDKStrategy can only be used with GretelModel"
+            )
+
+        return self.job_spec.model
 
     def runnable(self) -> bool:
         return self.benchmark_model.runnable(self.dataset)

--- a/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
+++ b/src/gretel_trainer/benchmark/gretel/strategy_trainer.py
@@ -16,7 +16,7 @@ from gretel_trainer.benchmark.job_spec import JobSpec
 class GretelTrainerStrategy:
     def __init__(
         self,
-        job_spec: JobSpec,
+        job_spec: JobSpec[GretelModel],
         run_identifier: str,
         project_name: str,
         config: BenchmarkConfig,
@@ -36,11 +36,6 @@ class GretelTrainerStrategy:
 
     @property
     def benchmark_model(self) -> GretelModel:
-        if not isinstance(self.job_spec.model, GretelModel):
-            raise BenchmarkException(
-                "GretelSDKStrategy can only be used with GretelModel"
-            )
-
         return self.job_spec.model
 
     def runnable(self) -> bool:

--- a/src/gretel_trainer/benchmark/job_spec.py
+++ b/src/gretel_trainer/benchmark/job_spec.py
@@ -64,7 +64,7 @@ ModelTypes = Union[
 ]
 
 
-def model_name(model: ModelTypes):
+def model_name(model: ModelTypes) -> str:
     if isinstance(model, GretelModel):
         return model.name
     elif isclass(model):

--- a/src/gretel_trainer/benchmark/job_spec.py
+++ b/src/gretel_trainer/benchmark/job_spec.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass
-from typing import Any, Generic, Optional, TypeVar, Union
+from inspect import isclass
+from typing import Generic, Type, TypeVar, Union
 
 from gretel_trainer.benchmark.core import Dataset
+from gretel_trainer.benchmark.custom.datasets import CustomDataset
 from gretel_trainer.benchmark.custom.models import CustomModel
+from gretel_trainer.benchmark.gretel.datasets import GretelDataset
 from gretel_trainer.benchmark.gretel.models import GretelModel
 
 
@@ -48,18 +51,23 @@ class JobSpec(Generic[MODEL_BASE_TYPE]):
     Instance of a model that will be used.
     """
 
-    metadata: Optional[dict[str, Any]] = None
-    """
-    Arbitrary metadata that can be attached to the spec for context that may be used
-    by some implementation of executors/strategies.
-    """
-
     def make_run_key(self):
         return RunKey((model_name(self.model), self.dataset.name))
 
 
-def model_name(model: AnyModelType) -> str:
+DatasetTypes = Union[CustomDataset, GretelDataset]
+ModelTypes = Union[
+    CustomModel,
+    Type[CustomModel],
+    GretelModel,
+    Type[GretelModel],
+]
+
+
+def model_name(model: ModelTypes):
     if isinstance(model, GretelModel):
         return model.name
+    elif isclass(model):
+        return model.__name__
     else:
         return type(model).__name__

--- a/src/gretel_trainer/benchmark/job_spec.py
+++ b/src/gretel_trainer/benchmark/job_spec.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from gretel_trainer.benchmark.core import Dataset
 from gretel_trainer.benchmark.custom.models import CustomModel
 from gretel_trainer.benchmark.gretel.models import GretelModel
 
 
-# TODO(pm): Move this and JobSpec to `core`?
 class RunKey(tuple[str, str]):
     RUN_IDENTIFIER_SEPARATOR = "-"
 
@@ -31,19 +30,35 @@ class RunKey(tuple[str, str]):
         return f"({self.model_name}, {self.dataset_name})"
 
 
-@dataclass
-class JobSpec:
-    # TODO(pm): for simplicity just use Dataset instead of union
-    dataset: Dataset
+AnyModelType = Union[GretelModel, CustomModel]
+# `covariant=True` is needed, so that `list[GretelModel]` can be used where
+# `list[AnyModelType]` is used (see https://peps.python.org/pep-0484/#covariance-and-contravariance)
+MODEL_BASE_TYPE = TypeVar("MODEL_BASE_TYPE", bound=AnyModelType, covariant=True)
 
-    # TODO(pm): for simplicity, we only allow storing instantiated models here, no Type[X]
-    model: Union[GretelModel, CustomModel]
+
+@dataclass
+class JobSpec(Generic[MODEL_BASE_TYPE]):
+    dataset: Dataset
+    """
+    Instance of a dataset that will be used for training.
+    """
+
+    model: MODEL_BASE_TYPE
+    """
+    Instance of a model that will be used.
+    """
+
+    metadata: Optional[dict[str, Any]] = None
+    """
+    Arbitrary metadata that can be attached to the spec for context that may be used
+    by some implementation of executors/strategies.
+    """
 
     def make_run_key(self):
         return RunKey((model_name(self.model), self.dataset.name))
 
 
-def model_name(model: Union[GretelModel, CustomModel]) -> str:
+def model_name(model: AnyModelType) -> str:
     if isinstance(model, GretelModel):
         return model.name
     else:

--- a/src/gretel_trainer/benchmark/job_spec.py
+++ b/src/gretel_trainer/benchmark/job_spec.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Union
+
+from gretel_trainer.benchmark.core import Dataset
+from gretel_trainer.benchmark.custom.models import CustomModel
+from gretel_trainer.benchmark.gretel.models import GretelModel
+
+
+# TODO(pm): Move this and JobSpec to `core`?
+class RunKey(tuple[str, str]):
+    RUN_IDENTIFIER_SEPARATOR = "-"
+
+    @property
+    def model_name(self) -> str:
+        return self[0]
+
+    @property
+    def dataset_name(self) -> str:
+        return self[1]
+
+    @property
+    def identifier(self) -> str:
+        """Identifier returns a flat string identifying this run.
+
+        Returns:
+            A string identifying the run.
+        """
+        return self.RUN_IDENTIFIER_SEPARATOR.join(self)
+
+    def __repr__(self) -> str:
+        return f"({self.model_name}, {self.dataset_name})"
+
+
+@dataclass
+class JobSpec:
+    # TODO(pm): for simplicity just use Dataset instead of union
+    dataset: Dataset
+
+    # TODO(pm): for simplicity, we only allow storing instantiated models here, no Type[X]
+    model: Union[GretelModel, CustomModel]
+
+    def make_run_key(self):
+        return RunKey((model_name(self.model), self.dataset.name))
+
+
+def model_name(model: Union[GretelModel, CustomModel]) -> str:
+    if isinstance(model, GretelModel):
+        return model.name
+    else:
+        return type(model).__name__

--- a/src/gretel_trainer/benchmark/session.py
+++ b/src/gretel_trainer/benchmark/session.py
@@ -111,7 +111,7 @@ class Session:
 
         data_source_map = {}
         for job in self._jobs:
-            if artifact_key := data_source_map.get(job.dataset.data_source) is None:
+            if (artifact_key := data_source_map.get(job.dataset.data_source)) is None:
                 # TODO: avoid upload for public datasets, when possible
                 artifact_key = _upload_dataset_to_project(
                     job.dataset.data_source,

--- a/src/gretel_trainer/benchmark/session.py
+++ b/src/gretel_trainer/benchmark/session.py
@@ -86,9 +86,13 @@ class Session:
                 self._setup_gretel_run(job, artifact_key, _trainer_project_index)
                 _trainer_project_index += 1
 
-            else:
-                assert is_custom_model(job)
+            elif is_custom_model(job):
                 self._setup_custom_run(job, artifact_key)
+
+            else:
+                raise BenchmarkException(
+                    f"Unexpected model class received: {job.model.__class__.__name__}!"
+                )
 
         return self
 

--- a/src/gretel_trainer/benchmark/session.py
+++ b/src/gretel_trainer/benchmark/session.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+import pandas as pd
+from gretel_client.helpers import poll
+from gretel_client.projects import Project, create_project, search_projects
+from gretel_client.projects.jobs import Job
+
+from gretel_trainer.benchmark.core import BenchmarkConfig, BenchmarkException, Dataset
+from gretel_trainer.benchmark.custom.models import CustomModel
+from gretel_trainer.benchmark.custom.strategy import CustomStrategy
+from gretel_trainer.benchmark.executor import Executor
+from gretel_trainer.benchmark.gretel.models import GretelAuto, GretelModel
+from gretel_trainer.benchmark.gretel.strategy_sdk import GretelSDKStrategy
+from gretel_trainer.benchmark.gretel.strategy_trainer import GretelTrainerStrategy
+
+logger = logging.getLogger(__name__)
+
+ALL_REPORT_SCORES = {
+    "SQS": "synthetic_data_quality_score",
+    "FCS": "field_correlation_stability",
+    "PCS": "principal_component_stability",
+    "FDS": "field_distribution_stability",
+    "PPL": "privacy_protection_level",
+}
+
+
+class RunKey(tuple[str, str]):
+    RUN_IDENTIFIER_SEPARATOR = "-"
+
+    @property
+    def model_name(self) -> str:
+        return self[0]
+
+    @property
+    def dataset_name(self) -> str:
+        return self[1]
+
+    @property
+    def identifier(self) -> str:
+        """Identifier returns a flat string identifying this run.
+
+        Returns:
+            A string identifying the run.
+        """
+        return self.RUN_IDENTIFIER_SEPARATOR.join(self)
+
+    def __repr__(self) -> str:
+        return f"({self.model_name}, {self.dataset_name})"
+
+
+FutureKeyT = Union[str, RunKey]
+
+
+@dataclass
+class JobSpec:
+    # TODO(pm): for simplicity just use Dataset instead of union
+    dataset: Dataset
+
+    # TODO(pm): for simplicity, we only allow storing instantiated models here, no Type[X]
+    model: Union[GretelModel, CustomModel]
+
+
+def launch(*, jobs: list[JobSpec], config: Optional[BenchmarkConfig] = None) -> Session:
+    session = Session(jobs=jobs, config=config)
+    return session.prepare().execute()
+
+
+class Session:
+    def __init__(
+        self,
+        *,
+        jobs: list[JobSpec],
+        config: Optional[BenchmarkConfig] = None,
+    ):
+        self._jobs = jobs
+        self._config = config or BenchmarkConfig()
+
+        _validate_jobs(self._config, jobs)
+
+        self._gretel_executors: dict[RunKey, Executor] = {}
+        self._custom_executors: dict[RunKey, Executor] = {}
+        self._trainer_project_names: dict[str, str] = {}
+        self._thread_pool = ThreadPoolExecutor(5)
+        self._futures: dict[FutureKeyT, Future] = {}
+
+        self._report_scores = {
+            score_name: ALL_REPORT_SCORES[score_name]
+            for score_name in ["SQS"] + self._config.additional_report_scores
+        }
+
+    @property
+    def executors(self) -> dict[RunKey, Executor]:
+        return self._gretel_executors | self._custom_executors
+
+    def _make_project(self) -> Project:
+        display_name = self._config.project_display_name
+        if self._config.trainer:
+            display_name = f"{display_name}-evaluate"
+
+        return create_project(display_name=display_name)
+
+    def prepare(self) -> Session:
+        self._project = self._make_project()
+
+        _trainer_project_index = 0
+
+        data_source_map = {}
+        for job in self._jobs:
+            if artifact_key := data_source_map.get(job.dataset.data_source) is None:
+                # TODO: avoid upload for public datasets, when possible
+                artifact_key = _upload_dataset_to_project(
+                    job.dataset.data_source,
+                    self._project,
+                    self._config.trainer,
+                )
+                data_source_map[job.dataset.data_source] = artifact_key
+
+            if isinstance(job.model, GretelModel):
+                self._setup_gretel_run(
+                    job.dataset, job.model, artifact_key, _trainer_project_index
+                )
+                _trainer_project_index += 1
+
+            else:
+                self._setup_custom_run(job.dataset, job.model, artifact_key)
+
+        return self
+
+    def execute(self) -> Session:
+        for run_key, executor in self._gretel_executors.items():
+            self._futures[run_key] = self._thread_pool.submit(_run_gretel, executor)
+
+        if len(self._custom_executors) > 0:
+            self._futures["custom"] = self._thread_pool.submit(
+                _run_custom, list(self._custom_executors.values())
+            )
+
+        return self
+
+    @property
+    def results(self) -> pd.DataFrame:
+        result_records = [self._result_dict(run_key) for run_key in self.executors]
+        return pd.DataFrame.from_records(result_records)
+
+    def export_results(self, destination: str) -> None:
+        self.results.to_csv(destination, index=False)
+
+    def wait(self) -> Session:
+        [future.result() for future in self._futures.values()]
+        return self
+
+    def whats_happening(self) -> dict[str, str]:
+        return {
+            str(key): self._basic_status(future)
+            for key, future in self._futures.items()
+        }
+
+    def poll_job(self, model: str, dataset: str, action: str) -> None:
+        job = self._get_gretel_job(model, dataset, action)
+        poll(job)
+
+    def get_logs(self, model: str, dataset: str, action: str) -> list:
+        job = self._get_gretel_job(model, dataset, action)
+        return job.logs
+
+    def _get_gretel_job(self, model: str, dataset: str, action: str) -> Job:
+        run_key = RunKey((model, dataset))
+        executor = self.executors[run_key]
+        strategy = executor.strategy
+        if not isinstance(strategy, GretelSDKStrategy):
+            raise BenchmarkException("Cannot get Gretel job for non-GretelSDK runs")
+
+        if action == "train":
+            job = strategy.model
+        elif action == "generate":
+            job = strategy.record_handler
+        else:
+            raise BenchmarkException(
+                f"Unrecognized action `{action}` (must be `train` or `generate`)"
+            )
+
+        if job is None:
+            raise BenchmarkException("Gretel Job does not exist")
+
+        return job
+
+    def cleanup(self) -> None:
+        self._project.delete()
+
+        if self._config.trainer:
+            for project in search_projects(query=self._config.project_display_name):
+                project.delete()
+
+    def _result_dict(self, run_key: RunKey) -> dict[str, Any]:
+        executor = self.executors[run_key]
+        model_name, dataset_name = run_key
+
+        train_time = executor.strategy.get_train_time()
+        generate_time = executor.strategy.get_generate_time()
+
+        total_time = train_time
+        if train_time is not None and generate_time is not None:
+            total_time = train_time + generate_time
+
+        return {
+            "Input data": dataset_name,
+            "Model": model_name,
+            "DataType": executor.strategy.dataset.datatype,
+            "Rows": executor.strategy.dataset.row_count,
+            "Columns": executor.strategy.dataset.column_count,
+            "Status": executor.status.value,
+            **{
+                score_name: executor.get_report_score(score_key)
+                for score_name, score_key in self._report_scores.items()
+            },
+            "Train time (sec)": train_time,
+            "Generate time (sec)": generate_time,
+            "Total time (sec)": total_time,
+        }
+
+    def _setup_gretel_run(
+        self,
+        dataset: Dataset,
+        model: GretelModel,
+        artifact_key: Optional[str],
+        trainer_project_index: int,
+    ) -> None:
+        run_key = _make_run_key(model, dataset)
+        run_identifier = run_key.identifier
+        strategy = self._set_gretel_strategy(
+            benchmark_model=model,
+            dataset=dataset,
+            run_identifier=run_identifier,
+            trainer_project_index=trainer_project_index,
+            artifact_key=artifact_key,
+        )
+        executor = Executor(
+            strategy=strategy,
+            run_identifier=run_identifier,
+            evaluate_project=self._project,
+            config=self._config,
+        )
+        self._gretel_executors[run_key] = executor
+
+    def _setup_custom_run(
+        self,
+        dataset: Dataset,
+        model: CustomModel,
+        artifact_key: Optional[str] = None,
+    ) -> None:
+        run_key = _make_run_key(model, dataset)
+        run_identifier = run_key.identifier
+        strategy = CustomStrategy(
+            benchmark_model=model,
+            dataset=dataset,
+            run_identifier=run_identifier,
+            config=self._config,
+            artifact_key=artifact_key,
+        )
+        executor = Executor(
+            strategy=strategy,
+            run_identifier=run_identifier,
+            evaluate_project=self._project,
+            config=self._config,
+        )
+        self._custom_executors[run_key] = executor
+
+    def _basic_status(self, future: Future) -> str:
+        if future.done():
+            return "Finished"
+        elif future.cancelled():
+            return "Cancelled"
+        else:
+            return "Running"
+
+    def _set_gretel_strategy(
+        self,
+        benchmark_model: GretelModel,
+        dataset: Dataset,
+        run_identifier: str,
+        trainer_project_index: int,
+        artifact_key: Optional[str],
+    ) -> Union[GretelSDKStrategy, GretelTrainerStrategy]:
+        if self._config.trainer:
+            trainer_project_name = _trainer_project_name(
+                self._config, trainer_project_index
+            )
+            self._trainer_project_names[run_identifier] = trainer_project_name
+            return GretelTrainerStrategy(
+                benchmark_model=benchmark_model,
+                dataset=dataset,
+                run_identifier=run_identifier,
+                project_name=trainer_project_name,
+                config=self._config,
+            )
+        else:
+            return GretelSDKStrategy(
+                benchmark_model=benchmark_model,
+                dataset=dataset,
+                artifact_key=artifact_key,
+                run_identifier=run_identifier,
+                project=self._project,
+                config=self._config,
+            )
+
+
+def _run_gretel(executor: Executor) -> None:
+    executor.run()
+
+
+def _run_custom(executors: list[Executor]) -> None:
+    for executor in executors:
+        executor.run()
+
+
+def _validate_jobs(config: BenchmarkConfig, jobs: list[JobSpec]) -> None:
+    gretel_models = [j.model for j in jobs if isinstance(j.model, GretelModel)]
+    if config.trainer:
+        _validate_trainer_setup(gretel_models)
+    else:
+        _validate_sdk_setup(gretel_models)
+
+
+def _validate_trainer_setup(gretel_models: list[GretelModel]) -> None:
+    unsupported_models = []
+    for model in gretel_models:
+        if model.trainer_model_type is None:
+            logger.error(
+                f"Model `{model.name}` (model key `{model.model_key}`) is not supported by Trainer. "
+                "Either remove it from this comparison, or configure this comparison to use the SDK (trainer=False)"
+            )
+            unsupported_models.append(model)
+    if len(unsupported_models) > 0:
+        raise BenchmarkException("Invalid configuration")
+
+
+def _validate_sdk_setup(gretel_models: list[GretelModel]) -> None:
+    if any(isinstance(m, GretelAuto) for m in gretel_models):
+        logger.error(
+            "GretelAuto is only supported when using Trainer. "
+            "Either remove it from this comparison, or configure this comparison to use Trainer (trainer=True)"
+        )
+        raise BenchmarkException("Invalid configuration")
+
+
+def model_name(model: Union[GretelModel, CustomModel]) -> str:
+    if isinstance(model, GretelModel):
+        return model.name
+    else:
+        return type(model).__name__
+
+
+def _trainer_project_name(config: BenchmarkConfig, index: int) -> str:
+    prefix = config.project_display_name
+    name = f"{prefix}-{index}"
+    return name.replace("_", "-")
+
+
+def _upload_dataset_to_project(
+    source: str, project: Project, trainer: bool
+) -> Optional[str]:
+    if trainer:
+        return None
+
+    return project.upload_artifact(source)
+
+
+def _make_run_key(model: Union[GretelModel, CustomModel], dataset: Dataset) -> RunKey:
+    return RunKey((model_name(model), dataset.name))

--- a/src/gretel_trainer/benchmark/session.py
+++ b/src/gretel_trainer/benchmark/session.py
@@ -28,15 +28,7 @@ ALL_REPORT_SCORES = {
     "PPL": "privacy_protection_level",
 }
 
-
 FutureKeyT = Union[str, RunKey]
-
-
-def launch(
-    *, jobs: list[JobSpec[AnyModelType]], config: Optional[BenchmarkConfig] = None
-) -> Session:
-    session = Session(jobs=jobs, config=config)
-    return session.prepare().execute()
 
 
 class Session:

--- a/src/gretel_trainer/benchmark/session.py
+++ b/src/gretel_trainer/benchmark/session.py
@@ -263,8 +263,10 @@ class Session:
                 config=self._config,
             )
 
+
 def is_gretel_model(job: JobSpec[AnyModelType]) -> TypeGuard[JobSpec[GretelModel]]:
     return isinstance(job.model, GretelModel)
+
 
 def is_custom_model(job: JobSpec[AnyModelType]) -> TypeGuard[JobSpec[CustomModel]]:
     return not isinstance(job.model, GretelModel)
@@ -280,7 +282,7 @@ def _run_custom(executors: list[Executor]) -> None:
 
 
 def _validate_jobs(config: BenchmarkConfig, jobs: list[JobSpec[AnyModelType]]) -> None:
-    gretel_models = [j.model for j in jobs if isinstance(j.model, GretelModel)]
+    gretel_models = [j.model for j in jobs if is_gretel_model(j)]
     if config.trainer:
         _validate_trainer_setup(gretel_models)
     else:

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -12,9 +12,9 @@ IRIS = REPO.get_dataset("iris")
 
 
 @pytest.fixture(autouse=True)
-def patch_configure_session():
-    with patch("gretel_trainer.benchmark.entrypoints._verify_client_config"):
-        yield
+def patch_verify_config():
+    with patch("gretel_trainer.benchmark.entrypoints._verify_client_config") as p:
+        yield p
 
 
 @pytest.fixture(autouse=True)

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -40,7 +40,7 @@ def df():
 
 @pytest.fixture()
 def project():
-    with patch("gretel_trainer.benchmark.comparison.create_project") as create_project:
+    with patch("gretel_trainer.benchmark.session.create_project") as create_project:
         project = Mock()
         create_project.return_value = project
         yield project

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -12,6 +12,12 @@ IRIS = REPO.get_dataset("iris")
 
 
 @pytest.fixture(autouse=True)
+def patch_configure_session():
+    with patch("gretel_trainer.benchmark.entrypoints._verify_client_config"):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def sleepless():
     with patch("time.sleep"):
         yield

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -12,12 +12,6 @@ IRIS = REPO.get_dataset("iris")
 
 
 @pytest.fixture(autouse=True)
-def patch_configure_session():
-    with patch("gretel_trainer.benchmark.comparison.configure_session"):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def sleepless():
     with patch("time.sleep"):
         yield

--- a/tests/benchmark/test_bad_setup.py
+++ b/tests/benchmark/test_bad_setup.py
@@ -13,9 +13,9 @@ def test_bad_session_exits_early(iris, tmp_path):
     should_not_be_created = tmp_path / "should_not_be_created"
 
     with patch(
-        "gretel_trainer.benchmark.comparison.configure_session"
-    ) as configure_session:
-        configure_session.side_effect = SomeException()
+        "gretel_trainer.benchmark.entrypoints._verify_client_config"
+    ) as verify_client_config:
+        verify_client_config.side_effect = SomeException()
 
         with pytest.raises(SomeException):
             compare(

--- a/tests/benchmark/test_bad_setup.py
+++ b/tests/benchmark/test_bad_setup.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 
 import pytest
@@ -7,9 +6,11 @@ from gretel_trainer.benchmark import GretelLSTM, compare
 from gretel_trainer.benchmark.core import BenchmarkConfig, BenchmarkException
 
 
-def test_bad_session_exits_early(iris):
+def test_bad_session_exits_early(iris, tmp_path):
     class SomeException(Exception):
         pass
+
+    should_not_be_created = tmp_path / "should_not_be_created"
 
     with patch(
         "gretel_trainer.benchmark.comparison.configure_session"
@@ -21,32 +22,36 @@ def test_bad_session_exits_early(iris):
                 datasets=[iris],
                 models=[GretelLSTM],
                 config=BenchmarkConfig(
-                    working_dir="should_not_be_created",
+                    working_dir=should_not_be_created,
                 ),
             )
 
-    assert not os.path.exists("should_not_be_created")
+    assert not should_not_be_created.exists()
 
 
-def test_dataset_names_must_be_unique(iris):
+def test_dataset_names_must_be_unique(iris, tmp_path):
+    should_not_be_created = tmp_path / "should_not_be_created"
+
     with pytest.raises(BenchmarkException):
         compare(
             datasets=[iris, iris],
             models=[GretelLSTM],
             config=BenchmarkConfig(
-                working_dir="should_not_be_created",
+                working_dir=should_not_be_created,
             ),
         )
-    assert not os.path.exists("should_not_be_created")
+    assert not should_not_be_created.exists()
 
 
-def test_model_names_must_be_unique(iris):
+def test_model_names_must_be_unique(iris, tmp_path):
+    should_not_be_created = tmp_path / "should_not_be_created"
+
     with pytest.raises(BenchmarkException):
         compare(
             datasets=[iris],
             models=[GretelLSTM, GretelLSTM],
             config=BenchmarkConfig(
-                working_dir="should_not_be_created",
+                working_dir=should_not_be_created,
             ),
         )
-    assert not os.path.exists("should_not_be_created")
+    assert not should_not_be_created.exists()

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -354,7 +354,7 @@ def test_compare_creates_job_specs(working_dir, project, iris):
     assert {d.name for d, m in do_nothing_jobs} == {"iris", "skippy"}
 
 
-def test_custom_models_dont_verify_client_config(patch_verify_config, iris):
+def test_custom_models_dont_verify_client_config(patch_verify_config, iris, project):
     compare(datasets=[iris], models=[DoNothingModel])
     assert patch_verify_config.call_count == 0
 

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -15,6 +15,7 @@ from gretel_trainer.benchmark import (
     GretelLSTM,
     compare,
     create_dataset,
+    launch,
 )
 from tests.benchmark.mocks import (
     DoNothingModel,
@@ -32,7 +33,7 @@ def test_run_with_gretel_dataset(working_dir, project, evaluate_report_path, iri
     evaluate_model.get_artifact_link.return_value = evaluate_report_path
     project.create_model_obj.side_effect = [evaluate_model]
 
-    comparison = compare(
+    session = compare(
         datasets=[iris],
         models=[DoNothingModel],
         config=BenchmarkConfig(
@@ -40,8 +41,8 @@ def test_run_with_gretel_dataset(working_dir, project, evaluate_report_path, iri
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     _iris_shape = pd.read_csv(iris.data_source).shape
     assert result["Input data"] == "iris"
     assert result["Model"] == "DoNothingModel"
@@ -63,7 +64,7 @@ def test_run_with_custom_csv_dataset(working_dir, project, evaluate_report_path,
 
         dataset = create_dataset(f.name, datatype="tabular", name="pets")
 
-        comparison = compare(
+        session = compare(
             datasets=[dataset],
             models=[DoNothingModel],
             config=BenchmarkConfig(
@@ -71,8 +72,8 @@ def test_run_with_custom_csv_dataset(working_dir, project, evaluate_report_path,
             ),
         ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     assert result["Input data"] == "pets"
     assert result["Model"] == "DoNothingModel"
     assert result["Rows"] == 3
@@ -93,7 +94,7 @@ def test_run_with_custom_psv_dataset(working_dir, project, evaluate_report_path,
 
         dataset = create_dataset(f.name, datatype="tabular", name="pets", delimiter="|")
 
-        comparison = compare(
+        session = compare(
             datasets=[dataset],
             models=[DoNothingModel],
             config=BenchmarkConfig(
@@ -101,8 +102,8 @@ def test_run_with_custom_psv_dataset(working_dir, project, evaluate_report_path,
             ),
         ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     assert result["Input data"] == "pets"
     assert result["Model"] == "DoNothingModel"
     assert result["Rows"] == 3
@@ -122,7 +123,7 @@ def test_run_with_custom_dataframe_dataset(
 
     dataset = create_dataset(df, datatype="tabular", name="pets")
 
-    comparison = compare(
+    session = compare(
         datasets=[dataset],
         models=[DoNothingModel],
         config=BenchmarkConfig(
@@ -130,8 +131,8 @@ def test_run_with_custom_dataframe_dataset(
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     assert result["Input data"] == "pets"
     assert result["Model"] == "DoNothingModel"
     assert result["Rows"] == 3
@@ -173,7 +174,7 @@ def test_run_happy_path_gretel_sdk(
         "gretel_trainer.benchmark.gretel.strategy_sdk.GretelSDKStrategy._get_record_handler_data"
     ) as get:
         get.return_value = Mock(content=gzip.compress(b"synthetic,data\n1,3\n2,4"))
-        comparison = compare(
+        session = compare(
             datasets=[iris],
             models=[benchmark_model],
             config=BenchmarkConfig(
@@ -181,8 +182,8 @@ def test_run_happy_path_gretel_sdk(
             ),
         ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     model_name = benchmark_model.__name__
     assert result["Model"] == model_name
     assert result["Status"] == "Complete"
@@ -210,7 +211,7 @@ def test_sdk_model_failure(working_dir, iris, project):
 
     project.create_model_obj.side_effect = [model]
 
-    comparison = compare(
+    session = compare(
         datasets=[iris],
         models=[GretelLSTM],
         config=BenchmarkConfig(
@@ -218,8 +219,8 @@ def test_sdk_model_failure(working_dir, iris, project):
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    result = comparison.results.iloc[0]
+    assert len(session.results) == 1
+    result = session.results.iloc[0]
     assert result["Model"] == "GretelLSTM"
     assert result["Status"] == "Failed (train)"
     assert result["SQS"] is None
@@ -229,7 +230,7 @@ def test_sdk_model_failure(working_dir, iris, project):
 
 
 def test_run_with_failures(working_dir, project, iris):
-    comparison = compare(
+    session = compare(
         datasets=[iris],
         models=[FailsToTrain, FailsToGenerate],
         config=BenchmarkConfig(
@@ -237,8 +238,8 @@ def test_run_with_failures(working_dir, project, iris):
         ),
     ).wait()
 
-    assert len(comparison.results) == 2
-    assert set(comparison.results["Status"]) == {"Failed (train)", "Failed (generate)"}
+    assert len(session.results) == 2
+    assert set(session.results["Status"]) == {"Failed (train)", "Failed (generate)"}
 
 
 def test_custom_gretel_model_configs_do_not_overwrite_each_other(
@@ -276,7 +277,7 @@ def test_gptx_skips_too_many_columns(working_dir, project):
         two_columns, datatype=Datatype.NATURAL_LANGUAGE, name="skippy"
     )
 
-    comparison = compare(
+    session = compare(
         datasets=[dataset],
         models=[GretelGPTX],
         config=BenchmarkConfig(
@@ -284,15 +285,15 @@ def test_gptx_skips_too_many_columns(working_dir, project):
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    assert_is_skipped(comparison.results.iloc[0])
+    assert len(session.results) == 1
+    assert_is_skipped(session.results.iloc[0])
 
 
 def test_gptx_skips_non_natural_language_datatype(working_dir, project):
     tabular = pd.DataFrame(data={"foo": [1, 2, 3]})
     dataset = create_dataset(tabular, datatype=Datatype.TABULAR, name="skippy")
 
-    comparison = compare(
+    session = compare(
         datasets=[dataset],
         models=[GretelGPTX],
         config=BenchmarkConfig(
@@ -300,15 +301,15 @@ def test_gptx_skips_non_natural_language_datatype(working_dir, project):
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    assert_is_skipped(comparison.results.iloc[0])
+    assert len(session.results) == 1
+    assert_is_skipped(session.results.iloc[0])
 
 
 def test_lstm_skips_datasets_with_over_150_columns(working_dir, project):
     jumbo = pd.DataFrame(columns=list(range(151)))
     dataset = create_dataset(jumbo, datatype=Datatype.TABULAR, name="skippy")
 
-    comparison = compare(
+    session = compare(
         datasets=[dataset],
         models=[GretelLSTM],
         config=BenchmarkConfig(
@@ -316,8 +317,49 @@ def test_lstm_skips_datasets_with_over_150_columns(working_dir, project):
         ),
     ).wait()
 
-    assert len(comparison.results) == 1
-    assert_is_skipped(comparison.results.iloc[0])
+    assert len(session.results) == 1
+    assert_is_skipped(session.results.iloc[0])
+
+
+def test_compare_creates_job_specs(working_dir, project, iris):
+    with patch("gretel_trainer.benchmark.entrypoints._entrypoint") as entrypoint:
+        dataset = create_dataset(
+            pd.DataFrame(data={"foo": [1, 2, 3]}),
+            datatype=Datatype.TABULAR,
+            name="skippy",
+        )
+
+        lstm = GretelLSTM()
+        compare(
+            datasets=[iris, dataset],
+            models=[DoNothingModel, lstm],
+            config=BenchmarkConfig(
+                working_dir=working_dir,
+            ),
+        )
+
+    assert entrypoint.call_count == 1
+    args, kwargs = entrypoint.call_args
+    assert args == ()
+
+    job_tuples = kwargs["jobs"]
+    assert len(job_tuples) == 4
+
+    lstm_jobs = [t for t in job_tuples if t[1] == lstm]
+    assert len(lstm_jobs) == 2
+    assert {d.name for d, m in lstm_jobs} == {"iris", "skippy"}
+
+    do_nothing_jobs = [t for t in job_tuples if t[1] == DoNothingModel]
+    assert len(do_nothing_jobs) == 2
+    assert {d.name for d, m in do_nothing_jobs} == {"iris", "skippy"}
+
+
+def test_custom_models_dont_verify_client_config(patch_verify_config, iris):
+    compare(datasets=[iris], models=[DoNothingModel])
+    assert patch_verify_config.call_count == 0
+
+    launch(jobs=[(iris, DoNothingModel)])
+    assert patch_verify_config.call_count == 0
 
 
 def assert_is_skipped(result):

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -354,14 +354,6 @@ def test_compare_creates_job_specs(working_dir, project, iris):
     assert {d.name for d, m in do_nothing_jobs} == {"iris", "skippy"}
 
 
-def test_custom_models_dont_verify_client_config(patch_verify_config, iris, project):
-    compare(datasets=[iris], models=[DoNothingModel])
-    assert patch_verify_config.call_count == 0
-
-    launch(jobs=[(iris, DoNothingModel)])
-    assert patch_verify_config.call_count == 0
-
-
 def assert_is_skipped(result):
     assert result["Status"] == "Skipped"
     assert result["SQS"] is None


### PR DESCRIPTION
Introduces `Session` as an encapsulation of _given a list of jobs, run them all and give me results_.
And uses that for 2 use cases:
- compare - given 2 lists: datasets and models, create cross product of them and run all the jobs.
- launch - given list of (dataset, model), run them all.