### PR TITLE
Re-add source_ prefix to archived source files

### DIFF
--- a/src/gretel_trainer/relational/multi_table.py
+++ b/src/gretel_trainer/relational/multi_table.py
@@ -924,7 +924,7 @@ class MultiTable:
             for table in self.relational_data.list_all_tables(Scope.ALL):
                 source_path = Path(self.relational_data.get_table_source(table))
                 filename = source_path.name
-                tar.add(source_path, arcname=filename)
+                tar.add(source_path, arcname=f"source_{filename}")
         self._artifact_collection.upload_source_archive(
             self._project, str(archive_path)
         )


### PR DESCRIPTION
In [the PR](https://github.com/gretelai/trainer/pull/130) moving source data from memory to disk, I introduced a bug in the creation of the source data archive (`source_tables.tar.gz`) that broke the restore-from-backup functionality.

#### Original backup-and-restore behavior

- Write each source table from Pandas DataFrame to a local CSV named `source_{table}.csv`
- Archive those files, upload the tar to the project as a project artifact
- When restoring from backup file, pull down the archive, unpack, and read those files back into DataFrames

#### Bug from previous PR

Since the tables now exist on disk and we only store pointers to them in memory, we don't need to call `dataframe.to_csv`; instead we just add the existing local files to the archive. The problem is that the filenames of the archived files changed—they no longer had the `source_` prefix but were instead just `{table}.csv`:
<img width="1360" alt="Screen Shot 2023-07-21 at 10 43 46 AM" src="https://github.com/gretelai/trainer/assets/2057981/0ef69161-5007-40f5-b62a-0ed4a6547779">
Consequently, when `restore` pulls down and unpacks the archive, it looks for files that do not exist (e.g. it tries to find `source_users.csv` but the file in the archive is just `users.csv`).

#### The fix (this PR)

Add the `source_` prefix to each table filename when adding it to the archive.