### PR TITLE
Dependency tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt -r test-requirements.txt
       - name: Install trainer
         run: pip install -e .
       - name: Type check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 boto3~=1.20
+dask[complete]==2023.5.1
 gretel-client>=0.16.0
 gretel-synthetics[utils]
 jinja2~=3.1
 networkx~=3.0
+numpy~=1.20
 pandas~=1.3
 plotly~=5.11
 pydantic~=1.9
@@ -11,4 +13,3 @@ scikit-learn~=1.0
 smart-open[s3]~=5.2
 sqlalchemy~=1.4
 unflatten==0.1.1
-dask[complete]==2023.5.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 black
 isort
 lxml


### PR DESCRIPTION
- numpy is imported explicitly in the `relational.extractor` and `relational.json` modules, but had not been declared an official dependency (it was getting pulled in transitively by pandas)
- rename dev/test requirements file to be consistent with our other public Python repos (gretel-client, gretel-synthetics)
- similarly, take out the `-r requirements.txt` helper and just explicitly install both files during workflow setup
  - I believe we could get away with only installing `-r test-requirements.txt` explicitly, and then the following `pip install -e .` line would handle installing the production/runtime requirements thanks to `install_requires` in `setup.py`. I don't have a strong opinion here.
- alphabetizing is good for you