### PR TITLE
Move benchmark log setup out of init

### DIFF
--- a/src/gretel_trainer/benchmark/__init__.py
+++ b/src/gretel_trainer/benchmark/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 from gretel_trainer.benchmark.core import BenchmarkConfig, Datatype
 from gretel_trainer.benchmark.custom.datasets import create_dataset, make_dataset
 from gretel_trainer.benchmark.entrypoints import compare, launch
@@ -18,20 +16,4 @@ from gretel_trainer.benchmark.gretel.models import (
     GretelLSTM,
     GretelModel,
 )
-
-log_format = "%(levelname)s - %(asctime)s - %(message)s"
-time_format = "%Y-%m-%d %H:%M:%S"
-formatter = logging.Formatter(log_format, time_format)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-
-# Clear out any existing root handlers
-# (This prevents duplicate log output in Colab)
-for root_handler in logging.root.handlers:
-    logging.root.removeHandler(root_handler)
-
-# Configure benchmark loggers
-logger = logging.getLogger("gretel_trainer.benchmark")
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel("INFO")
+from gretel_trainer.benchmark.log import set_log_level

--- a/src/gretel_trainer/benchmark/log.py
+++ b/src/gretel_trainer/benchmark/log.py
@@ -1,0 +1,24 @@
+import logging
+
+BENCHMARK = "gretel_trainer.benchmark"
+
+log_format = "%(levelname)s - %(asctime)s - %(message)s"
+time_format = "%Y-%m-%d %H:%M:%S"
+formatter = logging.Formatter(log_format, time_format)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+
+logger = logging.getLogger(BENCHMARK)
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel("INFO")
+
+# Clear out any existing root handlers
+# (This prevents duplicate log output in Colab)
+for root_handler in logging.root.handlers:
+    logging.root.removeHandler(root_handler)
+
+
+def set_log_level(level: str):
+    logger = logging.getLogger(BENCHMARK)
+    logger.setLevel(level)


### PR DESCRIPTION
This ensures default logging is still configured the way we want (e.g. INFO for all `gretel_trainer.benchmark` loggers, no duplicate output in Colab, etc.) without polluting the user's environment with variables like `logger`, `handler`, `time_format`, etc.

This also matches the setup in `relational`.