### PR TITLE
Handle nested lists of nested objects

### DIFF
--- a/tests/relational/test_relational_data_with_json.py
+++ b/tests/relational/test_relational_data_with_json.py
@@ -714,7 +714,7 @@ def test_restore_with_empty_tables(bball, invented_tables):
 
 
 @pytest.fixture
-def nested_listed_objects(tmpdir):
+def nested_lists_of_objects(tmpdir):
     json = """
 {
     "Records": [
@@ -744,7 +744,7 @@ def nested_listed_objects(tmpdir):
     return rel_data
 
 
-def test_nested_listed_objects(nested_listed_objects):
+def test_nested_lists_of_objects(nested_lists_of_objects):
     output_tables = {
         "demo_invented_1": pd.DataFrame(
             data={
@@ -770,7 +770,7 @@ def test_nested_listed_objects(nested_listed_objects):
         ),
     }
 
-    restored = nested_listed_objects.restore(output_tables)
+    restored = nested_lists_of_objects.restore(output_tables)
 
     pdtest.assert_frame_equal(
         restored["demo"],
@@ -807,7 +807,7 @@ def test_nested_listed_objects(nested_listed_objects):
 
 # TODO: This test documents current behavior, but ideally we'd improve our handling of this scenario
 # to retain more synthetic data from "deeper" levels that trained and ran successfully.
-def test_handles_missing_interior_invented_tables(nested_listed_objects):
+def test_handles_missing_interior_invented_tables(nested_lists_of_objects):
     # Same setup as the test above except we omit demo_invented_2
     # (simulating that table's model/rh erroring out)
     output_tables = {
@@ -830,7 +830,7 @@ def test_handles_missing_interior_invented_tables(nested_listed_objects):
         ),
     }
 
-    restored = nested_listed_objects.restore(output_tables)
+    restored = nested_lists_of_objects.restore(output_tables)
 
     pdtest.assert_frame_equal(
         restored["demo"],


### PR DESCRIPTION
Fixes a bug where relational JSON could not recompose lists of nested objects. See unit test for example. I've also filed a backlog ticket to improve how we handle the edge case documented in the second unit test.

This diff is pretty noisy because I wanted to add some comments / refactors / naming improvements to help explain what's going on and reduce the amount of time spent just figuring out what's going on next time we have to visit this. The actual fix was shockingly trivial, I will call it out inline.